### PR TITLE
[superseded by #6] dev v8.1.0 self-healing branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # Both engines: the v8.1.x Gemini failure went undiagnosed for weeks
+        # because e2e ran Chromium-only while the field failure was Firefox
+        # (Trusted Types). playwright.config.js advertises the Firefox project
+        # only when a Firefox build is present, so installing it here is what
+        # makes CI actually run the Gecko matrix.
+        run: npx playwright install --with-deps chromium firefox
       - name: Run e2e boot tests
         run: npm run test:e2e
       - name: Upload e2e results

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [8.2.0] — RELIABILITY OVERHAUL (post-Gemini hardening)
+
+With the Gemini root cause fixed in 8.1.5 (Trusted Types), this release works
+through the highest-value items from the failure audit — the ones that address
+*confirmed* weaknesses — while deliberately NOT rewriting working code on spec.
+
+### ✅ Tests now run in Firefox, not just Chromium
+The whole Gemini saga went undiagnosed for weeks because every e2e ran in
+Chromium while the field failure was Firefox Android — so Trusted Types
+enforcement was never exercised. Playwright now runs the full suite in **both
+Chromium and Firefox** (Gecko), and CI installs both. The Firefox project uses
+a mobile viewport + Android UA to approximate the reporter's device; it's
+desktop Gecko, not GeckoView, so treat passes as Gecko-validated, not
+Android-certified. Immediate payoff: the v8.1.5 Trusted Types fix is now
+**confirmed in real Gecko**, and Firefox caught a timing-flaky test on day one.
+
+### ✅ Transactional boot — one failing subsystem can't blank the panel
+Boot was a straight-line block: a throw in any step before the panel mounted
+(even an optional subsystem) aborted everything, and `__GITL_V8__` was committed
+before boot even ran, so a failed attempt permanently blocked a retry. Boot now
+runs as isolated phases: **critical** (styles → panel → render) fail loud;
+**optional** (continue-observer, heartbeat, tab-lock, bus, sentinel, boot-retry)
+are each caught and only degrade health (`GHOST._degraded`, Timeline
+`boot_phase`, `console … degraded:`). The singleton commits only after the panel
+is up.
+
+### ✅ Bounded, visibility-aware panel sentinel
+The 8.1.4 remount watchdog only checked *absence* and was unbounded — a page
+that re-hid the panel could drive an infinite append/remove storm. The sentinel
+now also rescues a panel that's been moved into a `display:none`/`hidden`/
+zero-size subtree, **caps** remounts (5 per 30s), and on exceeding the cap
+**opens a circuit breaker** with a visible note instead of thrashing. (Safe
+because Ghost never hides its own root — collapse only hides the inner body.)
+
+### ✅ Independent execution canary (`diagnostics/gitl-canary.user.js`)
+A standalone userscript, separate from core, that answers the one thing Ghost's
+own beacon can't: *did the manager execute a userscript here at all?* Badge but
+no panel → Ghost's fault; neither → manager/injection layer. Shadow-DOM host on
+`<html>`, built with DOM APIs (no innerHTML), so it's safe even on Trusted-Types
+pages. See `diagnostics/README.md`.
+
+### Deliberately deferred (honest scope)
+Two audit phases were **not** done, on purpose: a capability-split Gemini
+adapter rewrite (Phase 4) and a packaging/manager matrix + WXT build (Phase 6).
+Both touch working code or are large process/build efforts with low marginal
+value now that the actual bug is fixed and the adapter already has the
+send-veto + selector-memory hardening from 8.1.1. They're recorded in DEVLOG as
+future work rather than half-implemented.
+
+**303 unit + 52 e2e (26 × Chromium + 26 × Firefox), all green.**
+
 ## [8.1.5] — GEMINI ROOT CAUSE FOUND & FIXED (Trusted Types)
 
 ### 🎯 The actual cause — and the v8.1.4 banner is what caught it

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [8.1.3] — GEMINI SILENT BOOT CRASH
+
+### 🐞 FIX — Ghost "doesn't seem to load" on Gemini (and any page with a hardened window.fetch)
+No error, no panel, nothing — the worst kind of bug. A full-page capture of the
+live Gemini tab (SingleFile, which does capture other extensions' live DOM
+injections — Grammarly showed up fine) proved `#gitl` never mounted at all.
+Not a selector problem: the panel was never created.
+
+**Root cause:** `GITL_NET.install()` runs at module top-level, *outside*
+`safeBoot()`'s try/catch (which only wraps panel creation, much further
+down). It did three **unguarded** strict-mode property writes —
+`window.fetch =`, `XHR.prototype.open =`, `XHR.prototype.send =`. If a page
+has hardened any of those (`Object.defineProperty(..., {writable:false})` —
+a real pattern on security-conscious sites, plausible on a Google property),
+the assignment throws a TypeError right there, and because nothing catches
+it, the **entire script dies** before a single line of panel code runs.
+Confirmed by reproducing it: froze `window.fetch` before injecting the real
+script in a test browser — panel failed to mount, exactly as reported.
+
+**Fix:** every patch (fetch, XHR open, XHR send, WebSocket) is now
+individually try/catched, the whole `install()` method has an outer
+catch-all, and the top-level call site is guarded too. A hardened site now
+just loses that one piece of network telemetry — the panel, loop engine,
+and everything else boot completely normally. Verified with the same
+frozen-property reproduction now passing, for `fetch`, `XHR.send`, and
+both at once.
+
+### Prior boot failures are no longer invisible
+`lastBootError` was already being written to GM storage on a crash — but
+nothing ever read it back. Now, on the next successful boot, a stored prior
+failure surfaces once into Diagnostics (and therefore into any auto-report)
+and clears, instead of silently expiring in storage where no one could ever
+see why a previous load failed.
+
 ## [8.1.2] — TWO FIELD REPORTS CLOSED
 
 ### 🐞 FIX — Grok run paused itself 1 second after a perfectly good send (issue #2)

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [8.1.0] — SELF-HEALING BASE
+## [8.1.1] — SELF-HEALING BASE
 
 ### 🐞 FIX — DeepSeek clicked "Copy" instead of Send (field report)
 The heuristic send-finder scored ANY icon button near the composer (svg icon +1,

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [8.1.0] — SELF-HEALING BASE
+
+### 🐞 FIX — DeepSeek clicked "Copy" instead of Send (field report)
+The heuristic send-finder scored ANY icon button near the composer (svg icon +1,
+proximity +3 = past the 3.5 threshold), so DeepSeek's message "Copy" button won
+and the prompt got copied instead of sent.
+- **Semantic gate:** a candidate now needs a POSITIVE send signal (send word in
+  its label, `type=submit`, or same `<form>` as the composer). Icon + proximity
+  alone can never win again.
+- **Veto list expanded** to every message-action verb: copy, download, share,
+  edit, delete, regenerate, retry, like/dislike, read-aloud, translate, DeepThink…
+- **The veto now guards EVERY tier** — configured selectors and learned selectors
+  pass through `_sendLooksSafe()` too, so a rotted `div[class*="send"]` match
+  can't hand back a share widget.
+
+### 🐞 FIX — Models that don't echo the sigil stranded the loop ("No signal detected")
+DeepSeek (and some custom GPTs) answer fully but never print `[[GITL::PROCEED]]`.
+The run used to hard-pause after ~12 s of quiet.
+- **Sigil-free completion fallback:** when a reply finishes (generation ended,
+  text stable) with no sigil, Ghost now auto-continues ONCE with a protocol
+  reminder, and only pauses after **2 consecutive** sigil-free replies.
+  Every nudge still consumes a round, so drift guard / round limit keep their grip.
+- Streak resets the moment a real PROCEED/HALT arrives.
+- Fixed a latent crash: `Timeline.add()` (no such method) in the roadmap re-ask path.
+
+### 🔄 Re-detect actually finds the box now (field report: "refresh sometimes fails")
+Re-detect was one-shot — pressed at the exact moment an SPA is mid-remount, it
+missed and told you to try again.
+- **Keeps watching for 12 s** after a miss (MutationObserver + interval); reports
+  success the moment the composer appears, with a spinning 🔄 the whole time.
+- Clears **all** element caches now (the heuristic tier's 4 s cache was missed before).
+- Resets stale network stream counters (aborted background XHRs could fake
+  "still generating" after an app-switch).
+- One-time gentle focus nudge for editors that only mount their composer on focus
+  (never steals focus if you're typing somewhere).
+- **Silent self-heal:** returning to the tab with a detached cached composer now
+  drops caches automatically — most manual 🔄 presses just disappear.
+
+### 🧠 NEW — Selector Memory (self-healing locators)
+The industry-standard tier GITL was missing (Healenium-style): when configured
+selectors fail but the role/meaning heuristic finds the element, Ghost derives a
+STABLE selector from it (id > data-testid > aria-label > name > placeholder) —
+verified unique — and remembers it per-host. Next session tries the learned
+selector right after the configured ones, so a site redesign pays the heuristic
+cost once and the fix survives reloads. Capped at 12 hosts, self-pruning,
+learned send-selectors are veto-checked.
+
+### ⚠ Reporter — deduped + deeper
+- Identical auto-captures within 10 min no longer rebuild/re-send duplicates
+  (the `_seen` dedupe was declared in v7.1 but never wired).
+- Reports now include learned-selector state for the host.
+- 🔍 Probe selectors now shows all three tiers: configured / learned / heuristic.
+
+### 🌐 Workshop — share does the work now
+- **Share button** copies a paste-ready GitHub Discussions post: item list +
+  the full `.gitl.json` bundle in a code block. Then opens the how-to.
+- **Skins ride in the bundle:** exporting includes your active custom skin
+  (validated tokens only); importing a bundle with a skin applies it. A single
+  file now shares a complete look-and-brains pack. Skin-only bundles are valid.
+- Import stays additive-only: built-ins immutable, clashes auto-rename,
+  invalid skins skipped, never fatal.
+
 ## [8.0.0.13] — DEV BUILD d13
 
 ### 🐞 FIX — Perplexity paused itself mid-thought ("No signal detected")

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [8.1.2] — TWO FIELD REPORTS CLOSED
+
+### 🐞 FIX — Grok run paused itself 1 second after a perfectly good send (issue #2)
+`send_ok` at 14:34:05, `"Route changed — paused"` at 14:34:06. Grok (like most
+chat platforms) assigns the conversation a `/c/<uuid>` URL the instant the
+FIRST message goes out — that's the same conversation continuing, not real
+navigation, but the route watcher paused any running loop on ANY URL change.
+- The watcher now only pauses when the route change looks like a genuine
+  navigation away: different hostname, **or** nothing was sent in the last
+  15s to explain the URL move. A same-host URL change right after a send is
+  now just logged (`route_id_assigned`) and the loop keeps running.
+- Element caches are still cleared on every route change either way — a
+  same-host ID assignment can still remount the composer.
+
+### 🐞 FIX — Perplexity Deep Research paused mid-thought with "No output detected" (issue #1)
+Sent fine (`send_ok`), then two re-fires, then paused ~35s later even though
+Perplexity was still visibly "thinking" — Deep Research can run silently for
+minutes with **zero assistant DOM nodes yet**, not just no new growth.
+- d13 already taught the *later* no-signal branch to hold its stale counter
+  while `Adapter.isGenerating()` is true (network/stop-button witness) and
+  use each platform's `staleTicks` budget instead of a flat 5. That fix
+  never reached the *earlier* "no text exists yet" branch, which is exactly
+  what fires before Deep Research's first message container appears — so
+  slow-starting platforms could still pause ~12s after a good send.
+- Same treatment applied here: hold the counter while generating, use the
+  per-platform budget (Perplexity: 24 ticks).
+
+Both reproduced as real-browser Playwright tests before and after the fix
+(`tests/e2e/routefix.spec.js`, `tests/issuefixes.test.js`).
+
 ## [8.1.1] — SELF-HEALING BASE
 
 ### 🐞 FIX — DeepSeek clicked "Copy" instead of Send (field report)

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [8.1.4] — FAIL-LOUD BOOT + PANEL SELF-HEAL (Gemini diagnosis)
+
+### The honest status
+v8.1.3 was **confirmed installed and active** on the reporter's phone (Tampermonkey
+dashboard showed Version 8.1.3, enabled, matched on Gemini) and the panel STILL
+never entered the DOM — Gemini only; it mounts fine on other sites on the same
+device. So the v8.1.3 network-interceptor fix, though a real bug fix, was NOT the
+cause of this symptom. This release does not *claim* to fix Gemini — it makes the
+failure **diagnosable and self-healing**, because a static page-save plus a mobile
+console that only forwards one cross-origin-masked error can't say why boot fails.
+
+### 🔦 Boot beacon (works in a plain "save page" capture)
+`<html data-gitl-boot="…">` is written at each phase: `started` the instant the
+script runs, `ok:<ver>` once the panel is mounted, or `error:<stage>` if boot
+throws. A basic page save now reveals whether the script executed at all and how
+far it got — the single most useful signal, since that's the artifact we can get.
+
+### 📣 Fail-loud (no more silent death)
+The whole IIFE body is wrapped so ANY top-level throw — not just the network
+interceptor (there's a lot of pre-boot code: state build, crash recovery, history
+patching) — routes to `_gitlFatal()`: a `GM_notification` **and** a fixed banner
+injected at `documentElement` level (not `body`, which may be the missing/hostile
+thing). Previously such a throw died silently and `lastBootError` was invisible
+because the panel that displays it never mounted. Now you SEE the error and can
+screenshot it.
+
+### 🔁 Panel self-heal
+A watchdog re-mounts `#gitl` if the page framework removes it. Gemini's Angular
+shell is unusually aggressive about owning `document.body`, and a full re-render
+can wipe the panel out with no error thrown — a leading suspect for "installed and
+active but nothing shows up." Re-mount is logged (`panel_remount`) and reflected on
+the beacon (`remounted:N`).
+
+Verified in real Chromium: successful-boot beacon, a forced boot-throw showing the
+banner + `error:boot` beacon + persisted error, and panel re-mount after removal
+(`tests/e2e/bootdiag.spec.js`).
+
 ## [8.1.3] — GEMINI SILENT BOOT CRASH
 
 ### 🐞 FIX — Ghost "doesn't seem to load" on Gemini (and any page with a hardened window.fetch)

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [8.2.1] — send-target mislearn fix (issues #4, #5)
+
+Two field reports showed the self-healing SelectorMemory learning the **wrong**
+send control and then "sending" by clicking it:
+
+- **#5 (Grok)** learned `#model-select-trigger` — the model-picker dropdown.
+- **#4 (ChatGPT)** learned `#composer-plus-btn` — the "+" attach menu.
+
+Root cause: both controls sit *inside the composer form*, so the heuristic
+tier's "same-form" positive signal alone qualified them as a send button, and
+nothing inspected their `id` or the fact that they open a menu. The loop then
+"sent" by opening a dropdown, and the run stalled with *"No output detected."*
+
+### ✅ Structural popup-toggle veto
+`_sendLooksSafe` now rejects any candidate carrying `aria-haspopup` or
+`aria-expanded` — a send button submits, it never opens a menu or toggles a
+disclosure. This one check kills both field mislearns regardless of wording.
+
+### ✅ id folded into the veto surface
+The element `id` was never inspected before. It is now part of the label the
+veto runs against, and `SEND_VETO` gained `model|plus|tool|option|picker|
+dropdown|emoji|format`, so `#model-select-trigger` and `#composer-plus-btn`
+read as unsafe by name alone.
+
+### ✅ One veto gate for every tier
+`_heurSend` now routes its veto through `_sendLooksSafe` (single source of
+truth) instead of a private inline check, so the id + structural rules apply in
+the heuristic tier too. A persisted wrong selector also self-heals:
+`SelectorMemory.lookup('send')` already forgets a stored selector that fails
+`_sendLooksSafe`, so existing poisoned memory is dropped on next lookup.
+
+Send itself was never solely dependent on the button: the pipeline verifies the
+input actually cleared and falls through Enter → insertParagraph → form-submit,
+so vetoing a bad button degrades to those tiers rather than failing.
+
+New regression suite: `tests/mislearn.test.js`.
+
 ## [8.2.0] — RELIABILITY OVERHAUL (post-Gemini hardening)
 
 With the Gemini root cause fixed in 8.1.5 (Trusted Types), this release works

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [8.1.5] — GEMINI ROOT CAUSE FOUND & FIXED (Trusted Types)
+
+### 🎯 The actual cause — and the v8.1.4 banner is what caught it
+On the reporter's phone the v8.1.4 fail-loud banner read, on Gemini:
+> Element.innerHTML setter: **Sink type mismatch violation blocked by CSP**
+
+That is a **Trusted Types** violation. Gemini (a Google property) enforces
+`require-trusted-types-for 'script'` in its CSP. Under that policy, assigning a
+plain string to `.innerHTML` **throws** — and GITL builds its panel from
+`.innerHTML` templates, so the first render in the boot path threw and killed
+boot before the panel could mount. **This is exactly why it was Gemini-only:**
+no other supported platform (ChatGPT, Claude, Perplexity, DeepSeek, Grok…)
+enforces Trusted Types, so raw `.innerHTML` worked everywhere else. It was never
+a selector, a network hook, or a manager problem — every earlier guess was wrong.
+
+### The fix
+GITL now registers one Trusted Types policy (`gitl-ui`) at boot and routes its
+**four** `.innerHTML` sinks through it. On any site that does NOT enforce Trusted
+Types, the policy is never created and the wrapper returns the raw string —
+**byte-identical behaviour off Gemini, zero regression risk.** GITL only ever
+passes its own static templates through the policy (imported persona/workflow
+text is already escaped via `_esc` upstream), so it adds no injection surface.
+
+### Verified for real this time
+A new Chromium e2e loads the actual userscript on a page that genuinely enforces
+Trusted Types (`tests/e2e/trustedtypes.spec.js` + `mock-chat-tt.html`) and proves
+three things: (1) the fixture really enforces TT — a raw `innerHTML` throws;
+(2) v8.1.5 mounts `#gitl` anyway; (3) if a restrictive `trusted-types` allow-list
+were to block our policy, boot still fails LOUD (banner + error beacon), never a
+blank page. **Honest scope:** this is verified under Trusted Types enforcement in
+a real browser engine; final confirmation on the reporter's Firefox-Android +
+authenticated Gemini still rests with them — but the error it fixes is the exact
+one their device reported.
+
 ## [8.1.4] — FAIL-LOUD BOOT + PANEL SELF-HEAL (Gemini diagnosis)
 
 ### The honest status

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,38 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.1.2 — Two field-reported issues (GitHub #1, #2)
+
+### #1 Perplexity Deep Research paused mid-thought ("No output detected")
+- **What happened:** the d13 fix taught the LATER no-signal branch (ambiguous
+  `detectSignal` result) to hold its stale counter while `Adapter.isGenerating()`
+  is true. It never touched the EARLIER `if (!text)` branch — the one that
+  fires when zero assistant DOM nodes exist yet at all. Deep Research can sit
+  silently for a long time before its first message container even appears,
+  so that branch's hardcoded `>= 5` tick limit (~12s) fired first.
+- **Fix:** identical isGenerating()-witness + per-platform `staleTicks` budget
+  applied to the `!text` branch. Two branches, same failure mode, now the same
+  guard — worth checking whether any future signal-detection branch needs it too.
+
+### #2 Grok paused a running loop 1 second after a successful send
+- **What happened:** `history.pushState`/`replaceState` patch fires `gitl:route`
+  on ANY URL change; the handler paused any RUNNING loop unconditionally. Nearly
+  every chat platform assigns a conversation-id URL (`/` → `/c/<uuid>`) the
+  instant the first message sends — Grok's timeline showed `send_ok` then
+  `route pause` exactly one second apart.
+- **Rejected:** allowlisting per-platform URL patterns for "this is just an ID
+  assignment" — brittle, one more thing to maintain per site, breaks the moment
+  a platform changes its URL scheme.
+- **Done instead:** a same-host + "sent recently" heuristic (15s window, matches
+  `SEND_CONFIRM_MS` scale). Cross-host changes, or same-host changes with no
+  recent send, still pause — that's still probably a real navigation-away.
+  Caches are cleared either way regardless of the pause decision, since a
+  same-host ID assignment can still remount the composer under us.
+
+Both reproduced first as failing real-browser Playwright tests replaying the
+exact reported timeline, then fixed, then re-run green — not just unit-level
+string checks. `tests/e2e/routefix.spec.js`, `tests/issuefixes.test.js`.
+
 ## v8.1.1 — Self-healing base (send safety, sigil-free loops, selector memory)
 
 ### The DeepSeek "Copy" incident — why the send heuristic was structurally unsafe

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,58 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.1.5 — Gemini root cause: Trusted Types (found via the v8.1.4 banner)
+
+### The whole thread in one line
+Gemini enforces `require-trusted-types-for 'script'`; GITL renders with
+`.innerHTML = <string>`; under Trusted Types that assignment throws; it threw on
+the first render in the boot path, killing boot before the panel mounted. Only
+Gemini enforces TT among supported sites → Gemini-only symptom.
+
+### Why it took five releases and what actually cracked it
+- 8.1.3 guarded the network interceptor (real bug, wrong symptom).
+- 8.1.4 added fail-loud: a beacon + a banner injected with `textContent`/
+  `createElement` (deliberately NOT innerHTML, which is why the banner itself
+  survived the very CSP that was killing the panel). On the reporter's device
+  that banner printed the exact error: "Element.innerHTML setter: Sink type
+  mismatch violation blocked by CSP." THAT is what turned a week of guessing
+  into a five-minute diagnosis. Lesson banked: when you can't reproduce the
+  environment, spend the effort making the software report its own failure in a
+  way that can't be swallowed — it pays for itself immediately.
+- The external repair-pack the user brought (canary userscript, boot-supervisor,
+  panel-sentinel, hostile-shell tests) was good and correctly sequenced
+  (diagnose before rewrite), and it surfaced two genuine findings worth keeping
+  regardless: `__GITL_V8__` is committed before boot succeeds (blocks same-page
+  retry), and Playwright is Chromium-only while the field is Firefox. Neither is
+  the Gemini cause, but both are real; see follow-ups. The canary wasn't needed
+  in the end because the banner already proved GITL executes on Gemini — it just
+  threw on innerHTML.
+
+### The fix and its bound
+One `gitl-ui` policy created at boot; 4 innerHTML sinks wrapped in `_TT()`.
+`_TT` is a pure pass-through when `trustedTypes` is absent (every non-Gemini
+site), so behaviour there is unchanged. Named (not default) policy so we never
+touch Gemini's own default/named policies — page-scoped, minimal blast radius.
+Only GITL's own static templates go through it; imported text is `_esc`-escaped
+upstream, so no new injection surface.
+
+### Residual risk (stated honestly, not papered over)
+If a site enforced TT AND shipped a restrictive `trusted-types` allow-list that
+forbids creating our `gitl-ui` policy, `createPolicy` throws, `_ttPolicy` stays
+null, and the first innerHTML would still throw — but now it fails LOUD (banner +
+`error:` beacon + a `tt-policy-blocked` beacon marker) instead of a blank page,
+and the real remedy would be a DOM-built panel (no innerHTML at all). Gemini's
+banner reported a SINK violation, not a policy-creation violation, which is
+consistent with "no policy existed yet," and most `require-trusted-types-for`
+deployments don't also ship a name allow-list — so the policy approach is very
+likely sufficient on Gemini. Covered both ways in trustedtypes.spec.js.
+
+### Follow-ups (not done here; from the repair-pack audit, now de-risked)
+1. Commit `__GITL_V8__` only after critical boot phases (transactional boot).
+2. Add a Firefox Playwright project so tests run in the engine that actually
+   failed. TT is spec-level so the Chromium proof is strong, but the field is
+   Firefox Android and that gap should close.
+
 ## v8.1.4 — Gemini "installed + active but nothing shows" (diagnosis, not a claimed fix)
 
 ### Where the previous fix went wrong

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,68 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.1.3 — Gemini silent boot crash (GITL_NET.install() unguarded)
+
+### The bug
+`GITL_NET.install()` is called at module top-level (`GITL_NET.install();`,
+right after the object literal) — deliberately, per its own comment,
+"install immediately — safe even before DOM," because network interception
+needs to be live before the very first fetch/XHR the page makes, which can
+happen before `document.body` exists. That's a legitimate reason to run
+outside `safeBoot()`. The bug was that "runs outside safeBoot" quietly also
+meant "runs with zero exception handling," and three of its four property
+patches (fetch, XHR.open, XHR.send) were bare assignments — no try/catch —
+while the fourth (WebSocket) already had one. That asymmetry was the tell.
+
+In strict mode (`'use strict'` at the top of the file), assigning to a
+property a page has hardened via `Object.defineProperty(..., {writable:
+false, configurable:false})` throws a TypeError synchronously. Nothing
+catches it at module scope, so the throw aborts the rest of the IIFE
+entirely — including `safeBoot(() => {...})`, which is defined and CALLED
+much later in the same top-level script flow and simply never gets reached.
+Net effect: zero panel, zero console message a normal user would ever
+notice (Tampermonkey/browser DO log the uncaught exception to devtools
+console, but essentially no one checks that), zero `lastBootError` entry
+either (that capture only lives inside safeBoot's catch, which never ran).
+
+### How this was found without live access to gemini.google.com
+Couldn't reproduce live (Gemini needs a Google login this sandbox doesn't
+have). The user attached a full-page capture of the actual failing tab, made
+with the SingleFile browser extension — which captures the live DOM
+including other extensions' injected content (confirmed: `data-gramm`
+attributes from Grammarly were present in the file). Searched the capture
+for `id="gitl"` and the literal string "GITL" — zero matches, anywhere, in
+a 4MB file. That ruled out "the script ran but couldn't find its
+selectors" (which would still leave the panel element in the DOM, just
+maybe empty/misconfigured) and pointed straight at "the script never
+finished executing far enough to create the panel at all." From there,
+tracing backward from `mountPanel()` up through everything that runs before
+it landed on the one unguarded, top-level, pre-safeBoot call.
+
+### Fix and how it was verified
+Wrapped each patch individually (matches the pattern the WebSocket patch
+already used), wrapped the whole `install()` body as a last resort, and
+wrapped the top-level call site too — three independent layers, because
+this is exactly the kind of bug where "should never happen" already
+happened once. Then reproduced the ORIGINAL failure in a real browser: used
+`page.addInitScript` to freeze `window.fetch` (and separately
+`XMLHttpRequest.prototype.send`) with `writable:false` *before* injecting
+the actual userscript source, confirmed the pre-fix code failed to mount
+`#gitl` (proving the repro was real, not a guess), then confirmed the fix
+resolves it for fetch alone, XHR alone, and both frozen at once.
+`tests/e2e/netboot.spec.js`.
+
+### Also fixed while in there: prior failures were a black hole
+`lastBootError` was captured on crash but never read back anywhere — pure
+write-only storage. A crash from six months ago and a crash from five
+minutes ago were equally invisible. Now surfaced into `DIAG` (and therefore
+into Reporter output) on the next successful boot, then cleared. Doesn't
+help the case where boot fails 100% of the time forever (nothing ever
+succeeds to surface it from) — the real fix for THAT class of bug is "don't
+let network interception take the whole panel down," which is the primary
+fix above. This is defense-in-depth for whatever the next unanticipated
+crash turns out to be.
+
 ## v8.1.2 — Two field-reported issues (GitHub #1, #2)
 
 ### #1 Perplexity Deep Research paused mid-thought ("No output detected")

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,66 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.2.0 — Reliability overhaul (working the failure audit, judiciously)
+
+The user brought a well-built external repair pack (canary, boot-supervisor,
+panel-sentinel, gemini-adapter-v2, hostile-shell tests, a 7-phase Claude-Code
+prompt). After 8.1.5 fixed the actual root cause (Trusted Types), the honest
+call was: do the phases that fix CONFIRMED weaknesses; do NOT rewrite working
+code on spec. Landed 5, 2, 3, 1 as separate reviewable commits; deferred 4, 6.
+
+### Phase 5 (Firefox) — done, and it earned its place immediately
+Added a Firefox project to playwright.config.js (Gecko is what enforces TT).
+Config detects a Firefox build in /opt/pw-browsers, PLAYWRIGHT_BROWSERS_PATH,
+or ~/.cache/ms-playwright, so CI's `playwright install firefox` actually runs
+(the naive /opt-only check would install it and never use it). On the first
+run Firefox caught a timing-armed forced-throw in bootdiag that raced boot in
+Gecko; made it deterministic (the boot observer is the first .observe() in
+execution order, so throw unconditionally). The 8.1.5 TT fix is now Gecko-proven.
+
+### Phase 2 (transactional boot) — done
+`__GITL_V8__` committed before boot + monolithic boot were the two confirmed
+findings. Boot is now phased: critical (styles→panel→render) fatal+loud;
+optional isolated (degrade health, never suppress the panel); singleton
+committed only after critical success; in-flight marker + history-patch guard
+so a retry can't double-wrap. A follow-on subtlety this created: breaking
+MutationObserver no longer fails boot (the continue-observer is optional now),
+so that e2e was repurposed to assert the NEW isolation behavior; critical-
+failure-is-loud stays covered by trustedtypes "policy blocked."
+
+### Phase 3 (bounded sentinel) — done
+Replaced the absence-only, unbounded 8.1.4 watchdog. Now visibility-aware
+(disconnected OR display:none/hidden/zero-size — a host may move #gitl into a
+hidden container), debounced, capped (5/30s), with a circuit breaker + visible
+note instead of an append/remove storm. Verified safe against Ghost's own
+collapsed state: collapse hides only .g-body; the root keeps ≥44px, so the
+sentinel never fights it.
+
+### Phase 1 (canary) — done, under diagnostics/
+Standalone, no core dependency, Shadow-DOM on <html>, DOM-API-built (no
+innerHTML — must survive the very TT CSP that broke Ghost). Guard test locks
+those properties. This is the tool that would have collapsed the original
+diagnosis from weeks to one screenshot.
+
+### Phases 4 & 6 — deferred, with reasons (not laziness)
+Phase 4 (capability-split adapter: findComposer/injectText/findSafeSendControl/
+send/isGenerating/readLastAssistant/diagnose) touches the WORKING send +
+generation-detection path. The adapter already got the send-safety veto +
+semantic gate + selector memory in 8.1.1, which covers the pack's main adapter
+concerns (no bare contenteditable acceptance survives the veto; proximity-first
+send search already exists in _heurSend). A full rewrite now is high regression
+risk for low marginal gain. Phase 6 (Tampermonkey/Violentmonkey/MV3 A-B matrix,
+first-class Firefox extension, WXT) is process/build/release work, largely
+docs + packaging, not a code defect. Both are real future work; neither is
+worth half-doing inside this pass. If the user wants either, they're now
+well-scoped.
+
+### Net
+303 unit + 52 e2e across two engines. The reliability posture is materially
+better: no single subsystem can blank the panel, the panel self-heals within
+bounds, boot failures are loud + retryable, and the exact engine that failed is
+now in the test matrix.
+
 ## v8.1.5 — Gemini root cause: Trusted Types (found via the v8.1.4 banner)
 
 ### The whole thread in one line

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,54 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.1.4 — Gemini "installed + active but nothing shows" (diagnosis, not a claimed fix)
+
+### Where the previous fix went wrong
+v8.1.3 guarded GITL_NET.install() and was verified against a frozen-window.fetch
+reproduction. Real bug, real fix — but the user's Tampermonkey dashboard then
+showed **8.1.3 installed, enabled, matched on Gemini**, and #gitl was still absent
+from a fresh page capture (Grammarly's data-gramm present in the same file =
+capture works; panel mounts fine on other sites on the same phone). So the frozen-
+fetch crash was NOT this symptom's cause. Lesson banked: I shipped and declared
+victory on a reproduction that tested a *different* failure mode than the user's.
+Don't do that. When the environment can't be reproduced (Firefox Android + Gemini,
+needs a Google login the sandbox lacks), make the software self-report instead of
+guessing again.
+
+### Why it was undiagnosable
+Every artifact available is blind to GITL's execution: a SingleFile save shows the
+DOM but not whether the script ran; MobiDevTools forwarded exactly one error across
+a 40s session and it was Gemini's own cross-origin-masked "Script error." at a
+gstatic BardChatUi bundle (present with and without our script — a red herring).
+And the existing lastBootError capture is circular: it's surfaced through the panel,
+which is the very thing that didn't mount.
+
+### What we added (all dependency-free, all work with no panel)
+1. Boot beacon on `<html data-gitl-boot>` — `started`/`ok:<ver>`/`error:<stage>`/
+   `remounted:N`. A plain page-save now answers "did it run, how far did it get."
+2. Whole-IIFE try/catch → `_gitlFatal()` → GM_notification + a banner injected at
+   documentElement level. Catches the entire "throws before safeBoot" class, not
+   just the network interceptor. safeBoot's own catch routes here too.
+3. Panel watchdog: re-mount #gitl if the framework removes it (leading Gemini
+   hypothesis — Angular owns document.body and can wipe children on re-render with
+   no throw).
+
+### Test-harness gotcha this introduced
+Wrapping the IIFE body in `try { … } catch(__gitlBootErr){}` block-scopes every
+const/function inside the try. The unit harness and two e2e specs injected their
+export hooks before the final `})();` — now OUTSIDE the try, where those symbols
+are invisible. Fixed all three to inject before the outer catch (still inside the
+try), with a fallback to the old position for pre-8.1.4 builds. If a future change
+moves the catch, those injection regexes need to move with it.
+
+### Still open
+This is a diagnosis play. Next Gemini load should either (a) show the panel
+(watchdog fixed an SPA removal), or (b) show a red banner / fire a notification with
+the actual error + set data-gitl-boot=error:<stage>. Either outcome finally tells
+us what's wrong. If the beacon reads `ok:8.1.4` yet the user still sees nothing,
+the panel is mounting and being hidden/covered (CSS/stacking/viewport) rather than
+missing — a different investigation.
+
 ## v8.1.3 — Gemini silent boot crash (GITL_NET.install() unguarded)
 
 ### The bug

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,7 +11,7 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
-## v8.1.0 — Self-healing base (send safety, sigil-free loops, selector memory)
+## v8.1.1 — Self-healing base (send safety, sigil-free loops, selector memory)
 
 ### The DeepSeek "Copy" incident — why the send heuristic was structurally unsafe
 - **Tried (v7→8.0):** score-based send finder: send-word +4, submit +2, svg-icon +1, same-form +3, proximity<320px +3, threshold 3.5, veto list of ~10 words.

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,44 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.2.1 — Send-target mislearn (issues #4, #5)
+
+**What was tried / observed.** Two `probe_fail` reports showed SelectorMemory
+had *learned* the wrong send control: `#model-select-trigger` on Grok (#5) and
+`#composer-plus-btn` on ChatGPT (#4). The loop then "sent" by opening a dropdown
+and stalled with "No output detected."
+
+**Why it happened.** `_heurSend`'s semantic gate accepts three positive signals:
+a send word, `type=submit`, or *same-form*. Both wrong controls live inside the
+composer form, so *same-form alone* qualified them, and nothing looked at their
+`id` or the fact that they open a menu. The DeepSeek-era veto only inspected
+aria-label/title/testid/text — never `id`, and had no structural check.
+
+**What we did instead.**
+1. Structural gate in `_sendLooksSafe`: any element with `aria-haspopup` or
+   `aria-expanded` is refused — a send button submits, it never opens a menu.
+   This is label-independent and kills both field cases directly.
+2. Folded `id` into the veto surface and added `model|plus|tool|option|picker|
+   dropdown|emoji|format` to `SEND_VETO`, so the two ids read unsafe by name.
+3. Made `_heurSend` use `_sendLooksSafe` as its single veto gate instead of a
+   private inline `SEND_VETO.test(label)` — id + structural rules now apply in
+   the heuristic tier too. Persisted poison self-heals: `lookup('send')` already
+   forgets a stored selector that fails `_sendLooksSafe`.
+
+**Why this is safe.** Send never depended solely on the button: the pipeline
+verifies the input actually cleared and falls through Enter → insertParagraph →
+form-submit. Refusing a bad button degrades to those tiers, not to no-send.
+
+**Coverage.** `tests/mislearn.test.js` (unit) + a same-form popup-toggle
+reproduction in `tests/e2e/sendsafety.spec.js`, both engines.
+
+**Honest limit.** #4 was mobile ChatGPT (Edge Mobile / Android) with *every*
+selector NO MATCH — a different DOM I can't fully verify without the device.
+This fix removes the mislearn poison and lets the role/meaning heuristics work,
+but full mobile-ChatGPT certification still needs a real-device confirmation.
+
+---
+
 ## v8.2.0 — Reliability overhaul (working the failure audit, judiciously)
 
 The user brought a well-built external repair pack (canary, boot-supervisor,

--- a/dev/DEVLOG.md
+++ b/dev/DEVLOG.md
@@ -11,6 +11,30 @@ Before starting any new work, read the relevant sections — you may be repeatin
 
 ---
 
+## v8.1.0 — Self-healing base (send safety, sigil-free loops, selector memory)
+
+### The DeepSeek "Copy" incident — why the send heuristic was structurally unsafe
+- **Tried (v7→8.0):** score-based send finder: send-word +4, submit +2, svg-icon +1, same-form +3, proximity<320px +3, threshold 3.5, veto list of ~10 words.
+- **What happened:** on DeepSeek, the assistant reply's Copy button (svg icon, ~200px from the composer) scored 1+3=4 → clicked. User's prompt was copied, not sent. Three retries in engineSend meant it clicked Copy repeatedly before falling through to Enter.
+- **Why it failed:** proximity+icon describes EVERY message-action button on a chat page. A veto list can never enumerate them all; the scoring itself must require positive intent.
+- **Learned / done instead:** (1) hard rule — candidates need a semantic positive (send word / type=submit / same-form) before scoring; (2) veto expanded to message-action verbs anyway (defense in depth); (3) the veto now wraps ALL tiers via `_sendLooksSafe()`, because configured selectors rot too (`div[class*="send"]` can match a share widget after a redesign). Regression suite: `tests/sendsafety.test.js`.
+
+### Sigil-free models (DeepSeek) — completion must not depend on the model's cooperation
+- **Tried:** relying on `[[GITL::PROCEED]]/[[GITL::HALT]]` echoes; stale-tick pause after ~12s quiet.
+- **What happened:** DeepSeek regularly answers fully, formats output in a code block, and never prints the sigil → every round ended in "No signal detected — review output".
+- **Learned:** quiescence (generation ended + text stable) IS the completion signal; the sigil is only the intent channel. Done instead: soft-proceed — one automatic "continue + protocol reminder" per sigil-free reply, pause only after 2 consecutive misses. Bounded by rounds/drift as usual. Do NOT raise the streak cap: a model that ignores the protocol twice will ignore it forever, and silent infinite nudging would burn the user's quota.
+
+### Re-detect was one-shot — the button raced the SPA remount
+- **What happened:** users press 🔄 at the exact moment the framework is rebuilding the composer; a single synchronous probe misses, message says "try again".
+- **Done instead:** 12s MutationObserver+interval watch after a miss; ALL caches cleared (the heuristic tier's 4s cache was previously missed — a stale-but-connected wrong element could survive re-detect); network stream counters zeroed; silent visibilitychange self-heal for the browser→app→browser case.
+
+### Selector memory (Healenium pattern, minimal port)
+- **Chosen:** persist a derived stable selector (id > data-testid > aria-label > name > placeholder, verified UNIQUE at learn time) per-host after a heuristic rescue; try it between configured and heuristic tiers. 12-host LRU cap. Learned send selectors re-checked against the veto at lookup.
+- **Rejected:** remote selector config (KeepChatGPT-style) — a remotely updatable selector feed is a supply-chain risk for a script that types into people's AI accounts; fingerprint similarity scoring (full Healenium) — overkill vs. the one-attribute derive, and heavy in a userscript.
+
+### Workshop share
+- Share was a doc link. Now `shareText()` builds the Discussions post (item list + bundle in a code block) and copies it. Skins ride in the bundle through the existing skin validator, so the security boundary is unchanged (token whitelist, fx enum, size caps).
+
 ## Session: v7.1.0 — IN PROGRESS (not yet released)
 
 Working build. Nothing pushed. Unit suite at 157/157 (was 140; +17 Workshop safety tests). Each feature below was syntax-checked and the full suite re-run before moving on.

--- a/dev/diagnostics/README.md
+++ b/dev/diagnostics/README.md
@@ -1,0 +1,49 @@
+# GITL Diagnostics
+
+Standalone tools that are **not** part of Ghost core. Install them only when
+you're chasing a "Ghost doesn't show up on site X" report.
+
+## `gitl-canary.user.js` — Execution Canary
+
+**The problem it solves.** Ghost's own boot beacon (`<html data-gitl-boot>`)
+and its fail-loud banner live *inside* Ghost. If a userscript manager never
+executes Ghost on a page at all — an injection or permission problem — that
+beacon is never written, and you can't tell that apart from "Ghost executed
+and crashed on the first line." The v8.1.x Gemini investigation stalled for
+exactly this reason until the fail-loud banner happened to survive and print
+the real error (a Trusted Types CSP violation).
+
+The canary is a **separate** userscript, so it isolates the layer:
+
+| Canary badge | Ghost panel | Conclusion |
+|---|---|---|
+| appears | appears | both fine on this site |
+| appears | absent | the fault is in **Ghost** — read the canary's `ghostBoot` field and Ghost's banner |
+| absent | absent | the fault is the **manager / injection layer** — no change to Ghost's code can help; check the manager is enabled and permitted on this site |
+
+It renders in a Shadow DOM host attached to `<html>` (survives body
+replacement and z-index wars) and is built with DOM APIs — **no `innerHTML`
+string sinks** — so it is safe even on Trusted-Types-enforced pages like
+Gemini, the very thing that broke Ghost.
+
+### How to use (mobile-friendly)
+1. Install `gitl-canary.user.js` in the same userscript manager as Ghost.
+2. Load the problem site. A small **GITL CANARY** badge appears top-right.
+   Its label also reports Ghost: `ghost:up`, `ghost:<beacon>`, or `ghost:absent`.
+3. Tap the badge to expand a copyable JSON report (manager name/version/inject
+   mode, body-replacement count, host-removal count, page errors, Ghost's
+   `data-gitl-boot`, whether `#gitl` is present, UA). Tap **Copy report** and
+   send it.
+
+### What each field means
+- `manager` / `managerVersion` / `injectInto` — from `GM_info`; proves the
+  manager ran the script and how it injects.
+- `bodyChanges` — how many times the page replaced `document.body` (SPA churn).
+- `hostRemovals` — how many times the page removed the canary's own host (a
+  proxy for how aggressively it would remove Ghost's panel).
+- `ghostBoot` / `ghostPanelPresent` — Ghost's beacon and whether its panel is
+  in the DOM, read from outside Ghost.
+- `errors` — `window.error` / `unhandledrejection` captured on the page.
+
+The canary is versioned independently (`@version` in its header) and has no
+dependency on Ghost core.

--- a/dev/diagnostics/gitl-canary.user.js
+++ b/dev/diagnostics/gitl-canary.user.js
@@ -1,0 +1,192 @@
+// ==UserScript==
+// @name         GITL Execution Canary
+// @namespace    https://github.com/MShneur/ghost-in-the-loop
+// @version      1.0.0
+// @description  Independent, mobile-safe canary that proves userscript execution, body replacement, panel-host removal, and manager identity — separate from Ghost core, so it can tell "the manager never ran my script" apart from "Ghost ran and crashed."
+// @match        https://chatgpt.com/*
+// @match        https://chat.openai.com/*
+// @match        https://gemini.google.com/*
+// @match        https://claude.ai/*
+// @match        https://www.perplexity.ai/*
+// @match        https://chat.deepseek.com/*
+// @match        https://copilot.microsoft.com/*
+// @match        https://grok.com/*
+// @run-at       document-start
+// @grant        GM_info
+// @grant        GM_setClipboard
+// @noframes
+// ==/UserScript==
+
+/*
+ * WHY THIS EXISTS (read diagnostics/README.md)
+ * Ghost's own boot beacon lives INSIDE Ghost. If a userscript manager never
+ * executes Ghost on a page (an injection/permission problem), that beacon is
+ * never written and you can't tell it apart from "Ghost ran and crashed."
+ * This canary is a *separate* userscript: if the canary badge appears but
+ * Ghost doesn't, the fault is in Ghost; if NEITHER appears, the fault is the
+ * manager/injection layer, and no change to Ghost's code can help.
+ *
+ * It renders in a Shadow DOM host attached to <html> (not <body>), so it
+ * survives body replacement and z-index/transform wars, and — importantly —
+ * it does NOT use innerHTML string sinks the way that broke Ghost on Gemini's
+ * Trusted Types CSP. It is intentionally trivial and dependency-free.
+ */
+(() => {
+  'use strict';
+
+  const STARTED_AT = new Date().toISOString();
+  const ID = 'gitl-canary-host';
+  const state = {
+    version: '1.0.0',
+    startedAt: STARTED_AT,
+    href: location.href,
+    readyStateAtStart: document.readyState,
+    manager: safe(() => GM_info.scriptHandler, 'unknown'),
+    managerVersion: safe(() => GM_info.version, 'unknown'),
+    injectInto: safe(() => GM_info.injectInto, 'unknown'),
+    ghostBoot: null,           // mirrors <html data-gitl-boot> if Ghost is present
+    bodyChanges: 0,
+    hostRemovals: 0,
+    ensureCalls: 0,
+    errors: [],
+    lastBodySeenAt: null,
+    lastEnsureAt: null,
+  };
+
+  let lastBody = null;
+  let host = null;
+  let shadow = null;
+  let detailOpen = false;
+  let observer = null;
+
+  function safe(fn, fallback) { try { return fn(); } catch (_) { return fallback; } }
+  function mark(value) { try { document.documentElement && document.documentElement.setAttribute('data-gitl-canary', value); } catch (_) {} }
+
+  function recordError(type, value) {
+    const text = String((value && value.message) || value || 'unknown').slice(0, 500);
+    state.errors.push({ type, text, at: new Date().toISOString() });
+    state.errors = state.errors.slice(-8);
+    render();
+  }
+
+  function report() {
+    return {
+      ...state,
+      href: location.href,
+      readyStateNow: document.readyState,
+      hidden: document.hidden,
+      focused: safe(() => document.hasFocus(), false),
+      hostConnected: Boolean(host && host.isConnected),
+      canaryMark: safe(() => document.documentElement.getAttribute('data-gitl-canary'), null),
+      ghostBoot: safe(() => document.documentElement.getAttribute('data-gitl-boot'), null),
+      ghostPanelPresent: safe(() => Boolean(document.getElementById('gitl')), false),
+      userAgent: navigator.userAgent,
+    };
+  }
+
+  function ensureHost() {
+    state.ensureCalls++;
+    state.lastEnsureAt = new Date().toISOString();
+    const html = document.documentElement;
+    if (!html) { queueMicrotask(ensureHost); return; }
+
+    if (!host) {
+      host = document.createElement('div');
+      host.id = ID;
+      host.setAttribute('data-owner', 'gitl-canary');
+      host.style.cssText = [
+        'all:initial', 'position:fixed',
+        'top:max(8px,env(safe-area-inset-top))', 'right:8px',
+        'z-index:2147483647', 'display:block',
+        'font-family:system-ui,sans-serif', 'pointer-events:auto',
+      ].join(';');
+      shadow = host.attachShadow({ mode: 'open' });
+      shadow.addEventListener('click', onClick);
+    }
+    if (!host.isConnected) { state.hostRemovals++; html.appendChild(host); }
+    if (document.body && document.body !== lastBody) {
+      lastBody = document.body;
+      state.bodyChanges++;
+      state.lastBodySeenAt = new Date().toISOString();
+    }
+    state.ghostBoot = report().ghostBoot;
+    mark(`alive:${state.version}:body${state.bodyChanges}:removal${state.hostRemovals}`);
+    render();
+  }
+
+  // NOTE: Shadow DOM is same-page and NOT under the page's Trusted Types policy
+  // for its own innerHTML, but to stay maximally safe we build with DOM APIs.
+  function render() {
+    if (!shadow) return;
+    const r = report();
+    const color = r.errors.length ? '#ff637d' : '#49d17d';
+    shadow.textContent = '';
+    const style = document.createElement('style');
+    style.textContent =
+      ':host{all:initial}' +
+      'button{all:unset;box-sizing:border-box;cursor:pointer;font:700 12px/1.2 system-ui,sans-serif}' +
+      `.badge{background:#111827;color:#f9fafb;border:1px solid ${color};border-radius:999px;padding:7px 10px;box-shadow:0 5px 20px #0008}` +
+      `.dot{color:${color};margin-right:5px}` +
+      '.card{margin-top:6px;width:min(360px,calc(100vw - 24px));max-height:55vh;overflow:auto;background:#0b1020;color:#e5e7eb;border:1px solid #334155;border-radius:10px;padding:10px;box-shadow:0 12px 36px #000b;font:11px/1.4 ui-monospace,monospace;white-space:pre-wrap;word-break:break-word}' +
+      '.row{display:flex;gap:6px;margin-top:8px}' +
+      '.action{background:#1e293b;border:1px solid #475569;border-radius:7px;padding:6px 8px;color:#f8fafc}';
+    shadow.appendChild(style);
+
+    const badge = document.createElement('button');
+    badge.className = 'badge';
+    badge.setAttribute('data-act', 'toggle');
+    const dot = document.createElement('span');
+    dot.className = 'dot'; dot.textContent = '●';
+    badge.appendChild(dot);
+    badge.appendChild(document.createTextNode(
+      'GITL CANARY ' + (r.errors.length ? 'ERROR' : 'ALIVE') +
+      (r.ghostPanelPresent ? ' · ghost:up' : r.ghostBoot ? ' · ghost:' + r.ghostBoot : ' · ghost:absent')));
+    shadow.appendChild(badge);
+
+    if (detailOpen) {
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.appendChild(document.createTextNode(JSON.stringify(r, null, 2)));
+      const row = document.createElement('div');
+      row.className = 'row';
+      const copy = document.createElement('button');
+      copy.className = 'action'; copy.setAttribute('data-act', 'copy'); copy.textContent = 'Copy report';
+      const reset = document.createElement('button');
+      reset.className = 'action'; reset.setAttribute('data-act', 'reset'); reset.textContent = 'Reset counts';
+      row.appendChild(copy); row.appendChild(reset);
+      card.appendChild(row);
+      shadow.appendChild(card);
+    }
+  }
+
+  function onClick(event) {
+    const t = event.target;
+    const act = t && t.closest && t.closest('[data-act]') && t.closest('[data-act]').getAttribute('data-act');
+    if (act === 'toggle') { detailOpen = !detailOpen; render(); }
+    else if (act === 'copy') {
+      const text = JSON.stringify(report(), null, 2);
+      try { GM_setClipboard(text, 'text'); }
+      catch (_) { navigator.clipboard && navigator.clipboard.writeText(text).catch(() => {}); }
+    } else if (act === 'reset') {
+      state.bodyChanges = 0; state.hostRemovals = 0; state.errors = []; render();
+    }
+  }
+
+  window.addEventListener('error', e => recordError('window.error', e.error || e.message), true);
+  window.addEventListener('unhandledrejection', e => recordError('unhandledrejection', e.reason), true);
+  document.addEventListener('readystatechange', ensureHost);
+  window.addEventListener('pageshow', ensureHost);
+  window.addEventListener('popstate', ensureHost);
+  document.addEventListener('visibilitychange', ensureHost);
+
+  function startObserver() {
+    if (observer || !document.documentElement) return;
+    observer = new MutationObserver(() => ensureHost());
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  mark('started');
+  ensureHost();
+  startObserver();
+  setInterval(ensureHost, 2000);
+})();

--- a/dev/docs/ARCHITECTURE.md
+++ b/dev/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ DEVLOG.md                    What was tried, what failed, why — read before re
 | **0.3** | 46–165 | Constants: VER, sigils, FUZZY lists |
 | **0.5** | 166–245 | Boot safety: `safeBoot()`, `claimTabLock()`, `releaseTabLock()`, `assertInteractionSafe()`, `GhostBus` init |
 | **0.7** | 246–330 | Network interceptor: `GITL_NET`, fetch/XHR proxy, `AI_ENDPOINTS` |
-| **1** | 331–460 | Platform profiles `PROFILES{}`, `_q()`, `_qAll()`, `Adapter{}` |
+| **1** | 331–460 | Platform profiles `PROFILES{}`, `_q()`, `_qAll()`, `SelectorMemory{}` (v8.1 learned locators), `Adapter{}` |
 | **2** | 461–570 | Libraries: `PERSONA_LIBRARY`, `WORKFLOW_LIBRARY` |
 | **3** | 571–700 | State: `GHOST{}`, `DIAG{}`, `platformHealth()`, `Timeline{}` |
 | **4** | 701–870 | Recovery engine: `RecoveryEngine{}` |
@@ -45,6 +45,24 @@ DEVLOG.md                    What was tried, what failed, why — read before re
 | **12** | 2300–2403 | Boot: `safeBoot(() => { ... })`, final IIFE close |
 
 ---
+
+## Element Lookup Tiers (v8.1)
+
+Every `Adapter.getInput()` / `getSendBtn()` resolves through four tiers, in order:
+
+1. **Configured** — `PLAT.input` / `PLAT.send` selector arrays (per-platform).
+2. **Learned** — `SelectorMemory` per-host selectors, derived (id > data-testid >
+   aria-label > name > placeholder, verified unique) after a heuristic rescue.
+   Persisted in `gitlLearnedSelectors`, 12-host LRU.
+3. **Heuristic** — role/meaning scoring. Send candidates REQUIRE a positive
+   semantic signal (send word / type=submit / same-form); svg + proximity alone
+   can never win (DeepSeek Copy incident, v8.1).
+4. **Veto (cross-cutting)** — `_sendLooksSafe()` rejects message-action verbs
+   (copy/download/share/edit/…) on EVERY tier's result.
+
+`reDetect()` is retrying (12 s MutationObserver + interval) and clears all
+caches including the heuristic tier's; a `visibilitychange` handler silently
+drops caches when the cached composer is found detached.
 
 ## Signal Engine Contract
 

--- a/dev/docs/ARCHITECTURE.md
+++ b/dev/docs/ARCHITECTURE.md
@@ -8,13 +8,17 @@
 ## File Structure
 
 ```
-ghost-in-the-loop.user.js    Main userscript (~3250 lines)
+ghost-in-the-loop.user.js    Main userscript (~4600 lines)
 extension/
   manifest.json              Firefox MV3 manifest
   content.js                 Built from userscript via sed extraction + GM shim header
+diagnostics/
+  gitl-canary.user.js        Standalone execution canary (NOT core; see its README)
+  README.md
 tests/
   setup.js                   VM harness: mocks GM_*, injects export hook into IIFE
-  *.test.js                  Unit tests (157 total)
+  *.test.js                  Unit tests (~300)
+  e2e/*.spec.js              Playwright, run in BOTH Chromium and Firefox (Gecko)
 docs/
   ARCHITECTURE.md            This file
 CHANGELOG.md                 What shipped per version
@@ -41,8 +45,49 @@ DEVLOG.md                    What was tried, what failed, why — read before re
 | **8** | 1091–1250 | Start/stop/queue, SPA route watcher |
 | **9** | 1251–1760 | Export: `extractMessages()`, `buildFilename()`, `apiExportChatGPT()`, `buildCapsuleV2()`, `exportCapsuleV2()` |
 | **10** | 1761–1800 | Audio |
-| **11** | 1801–2300 | UI: `renderXxx()` functions, CSS, `render()` |
-| **12** | 2300–2403 | Boot: `safeBoot(() => { ... })`, final IIFE close |
+| **11** | UI | `renderXxx()` functions, CSS, `render()`. All `.innerHTML` sinks route through `_TT()` (Trusted Types policy) — required on Gemini's `require-trusted-types-for 'script'` CSP. |
+| **12** | Boot | Beacon + `_gitlFatal()` fail-loud; transactional `safeBoot(() => { ...phases... })`; panel sentinel; final IIFE close (wrapped in top-level try→`_gitlFatal`). |
+
+*(Line-number ranges above are approximate and drift with edits; use them as a
+reading order, not addresses.)*
+
+---
+
+## Boot Contract (v8.2.0 — transactional)
+
+`safeBoot()` waits for `document.body`, then runs boot as isolated phases:
+
+- **Critical** (`styles → panel → render`): a failure throws → `_gitlFatal()`
+  (beacon `error:boot` + visible banner + `GM_notification`). The panel is the
+  product; if it can't render, fail LOUD, never blank+silent.
+- **Optional** (`continue-observer, heartbeat, tab-lock, bus, panel-sentinel,
+  boot-retry, prior-error-surface`): each caught; a failure pushes to
+  `GHOST._degraded` + Timeline `boot_phase{ok:false}` and is logged, but can
+  never suppress the panel or later phases.
+- The singleton `window.__GITL_V8__` is set to `true` **only after** the
+  critical phases succeed (a failed attempt no longer blocks a same-page retry;
+  an in-flight marker prevents concurrent double-exec).
+
+**Boot beacon** (`<html data-gitl-boot>`): `started` → `ok:<ver>` |
+`no-panel:<ver>` | `error:<stage>` | `remounted:N` | `sentinel-open`. Visible in
+a plain page-save — the primary field diagnostic.
+
+**Panel sentinel** (`startPanelSentinel`): treats the panel as down when
+disconnected OR `display:none`/`visibility:hidden`/zero-size; re-mounts (same
+node, state intact); capped 5/30s with a circuit breaker + visible note.
+Safe because Ghost never hides its own root (collapse hides only `.g-body`).
+
+**GITL_NET.install()** runs at top level (before `safeBoot`, so it beats the
+page's first fetch). Every patch is individually try/caught + the whole method
++ its call site — a hardened page can cost only its own network telemetry,
+never the panel.
+
+## Testing engines
+
+E2e runs in **Chromium and Firefox** (`playwright.config.js` advertises the
+Firefox project when a Firefox build is present; CI installs both). Firefox is
+desktop Gecko — the engine that enforces Trusted Types — not Android GeckoView,
+so passes are Gecko-validated, not Android-certified.
 
 ---
 

--- a/dev/docs/SKINS.md
+++ b/dev/docs/SKINS.md
@@ -13,6 +13,12 @@ The presets are not special — they use the exact same tokens and `fx` values
 available to you. Export any one of them to see how it's built.
 A working community example lives at `docs/skins/sakura.gitl.json`.
 
+## Sharing (v8.1)
+Workshop bundles can carry a skin: **⬇ Export** in Workshop includes your active
+custom skin, and importing a bundle with a `skin` field applies it (validated by
+the same whitelist — a bundled skin can't do anything a normal skin can't).
+The 🌐 Share button copies a paste-ready Discussions post with the JSON inline.
+
 ## The 30-second modding loop
 1. Setup tab → pick the preset closest to what you want → **⬇** (export)
 2. Edit the `.gitl.json` in any text editor

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -24,8 +24,15 @@ function GM_notification(detail) {
 _initStore().then(() => {
 (() => {
 'use strict';
-if (window.__GITL_V8__) return;
-window.__GITL_V8__ = true;
+/* v8.2.0 transactional boot: do NOT commit the singleton here. Committing it
+   before boot succeeded meant a partial/failed boot (e.g. the Trusted Types
+   throw) permanently blocked any same-page retry. `window.__GITL_V8__` is now
+   set to `true` only after the CRITICAL UI phases (styles → panel → render)
+   succeed. A short in-flight marker prevents concurrent double-execution
+   without poisoning a retry after a failed attempt. */
+if (window.__GITL_V8__ === true) return;                                          // already fully booted
+if (window.__GITL_BOOTING__ && Date.now() - window.__GITL_BOOTING__ < 15000) return; // an attempt is in flight
+window.__GITL_BOOTING__ = Date.now();
 
 /* ═══════════════════════════════════════════════════════════════
    BOOT BEACON + FAIL-LOUD (v8.1.4)
@@ -72,7 +79,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.5';
+const VER = '8.2.0';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -2369,6 +2376,9 @@ function primaryAction() {
    SPA ROUTE DETECTION
    ═══════════════════════════════════════════════════════════════ */
 (function patchHistory() {
+  // Guarded so a boot retry (top-level code re-running) can't double-wrap.
+  if (window.__GITL_HIST_PATCHED__) return;
+  window.__GITL_HIST_PATCHED__ = true;
   const orig = history.pushState;
   history.pushState = function(...a) { orig.apply(this, a); window.dispatchEvent(new Event('gitl:route')); };
   const origR = history.replaceState;
@@ -4517,96 +4527,178 @@ let _mutDebounce;
    BOOT — wrapped in safeBoot to prevent v7.0-alpha loading failures
    ═══════════════════════════════════════════════════════════════ */
 safeBoot(() => {
-  // Observer watches childList (new nodes) AND a narrow set of attributes
-  // (style/class/hidden), so a Continue button revealed via CSS — not just
-  // one freshly inserted — also triggers the auto-click fast-path.
-  // Loop tick (setInterval) remains the primary driver; this is a fast-path.
-  new MutationObserver(() => {
-    if (GHOST.loop.state !== 'RUNNING' || GHOST.loop.isSending) return;
-    clearTimeout(_mutDebounce);
-    _mutDebounce = setTimeout(() => { GHOST.loop.lastActivity = Date.now(); Adapter.clickContinue(); }, 300);
-  }).observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['style', 'class', 'hidden', 'disabled', 'aria-hidden']
+  /* v8.2.0 TRANSACTIONAL BOOT.
+     Previously boot was one straight-line block: any throw before mountPanel()
+     — including in an OPTIONAL subsystem like the tab bus or heartbeat — aborted
+     the rest and the panel never appeared. Now boot runs as isolated phases:
+       • CRITICAL phases (styles → panel → render) must succeed; a failure is
+         fatal AND loud (_gitlFatal via safeBoot's catch).
+       • OPTIONAL phases are each caught: one failing subsystem degrades health
+         and is logged, but can never suppress the panel or the phases after it.
+     The singleton `window.__GITL_V8__` is committed only after the critical
+     phases succeed, so a failed attempt no longer blocks a retry. */
+  GHOST._degraded = [];
+  const _phase = (name, critical, fn) => {
+    const t = Date.now();
+    try {
+      fn();
+      Timeline.record('boot_phase', { name, ok: true, ms: Date.now() - t });
+    } catch (e) {
+      Timeline.record('boot_phase', { name, ok: false, error: String(e && e.message || e) });
+      if (critical) throw new Error('critical boot phase "' + name + '" failed: ' + (e && e.message || e));
+      GHOST._degraded.push(name);
+      try { DIAG.push('Boot phase "' + name + '" failed (non-critical, panel unaffected): ' + (e && e.message || e)); } catch(_) {}
+    }
+  };
+
+  // ── CRITICAL: get the panel on screen. Nothing optional runs before this. ──
+  _phase('workshop', false, () => Workshop.load());   // custom items for first render; non-fatal if it throws
+  _phase('styles',   true,  () => injectStyles());
+  _phase('panel',    true,  () => mountPanel());
+  _phase('skin',     true,  () => SKIN.apply());
+  _phase('render',   true,  () => render());
+
+  // Panel is up and rendered — commit the singleton NOW (never before boot).
+  window.__GITL_V8__ = true;
+  window.__GITL_BOOTING__ = 0;
+  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
+
+  // ── OPTIONAL: isolated. None of these can remove the panel if they throw. ──
+  _phase('continue-observer', false, () => {
+    // Fast-path: a Continue button revealed via CSS (not just freshly inserted)
+    // also triggers the auto-click. The loop tick remains the primary driver.
+    new MutationObserver(() => {
+      if (GHOST.loop.state !== 'RUNNING' || GHOST.loop.isSending) return;
+      clearTimeout(_mutDebounce);
+      _mutDebounce = setTimeout(() => { GHOST.loop.lastActivity = Date.now(); Adapter.clickContinue(); }, 300);
+    }).observe(document.body, {
+      childList: true, subtree: true, attributes: true,
+      attributeFilter: ['style', 'class', 'hidden', 'disabled', 'aria-hidden']
+    });
+  });
+  _phase('heartbeat', false, () => startTabHeartbeat());
+  _phase('tab-lock',  false, () => claimTabLock());
+  _phase('bus',       false, () => GhostBus.init());
+  _phase('panel-sentinel', false, () => startPanelSentinel());
+
+  _phase('boot-retry', false, () => {
+    // SPA boot retry: ChatGPT/Gemini/Angular render chat elements late; keep
+    // trying to find input+send for 30s (every 2s), then stop.
+    let _bootRetry = 0;
+    const _bootInterval = setInterval(() => {
+      _bootRetry++;
+      const inp = _q('input', PLAT.input);
+      if (inp) {
+        clearInterval(_bootInterval);
+        GHOST.loop.detail = `✓ Connected to ${PLAT.label}`;
+        render();
+        DIAG.push(`Boot: elements found after ${_bootRetry * 2}s`);
+      } else if (_bootRetry >= 15) {
+        clearInterval(_bootInterval);
+        DIAG.push('Boot: gave up waiting for elements after 30s');
+      } else {
+        _cache.clear(); // re-attempt detect during SPA hydration
+      }
+    }, 2000);
   });
 
-  startTabHeartbeat();
-  claimTabLock();
-  GhostBus.init();
-  Workshop.load();
-  injectStyles();
-  mountPanel();
-  SKIN.apply();
-  render();
-
-  // SPA boot retry: ChatGPT/Gemini/Angular apps render chat elements late.
-  // Keep trying to find input+send for 30s after boot (every 2s).
-  // Once found, update status and stop retrying.
-  let _bootRetry = 0;
-  const _bootInterval = setInterval(() => {
-    _bootRetry++;
-    const inp = _q('input', PLAT.input);
-    if (inp) {
-      clearInterval(_bootInterval);
-      GHOST.loop.detail = `✓ Connected to ${PLAT.label}`;
-      render();
-      DIAG.push(`Boot: elements found after ${_bootRetry * 2}s`);
-    } else if (_bootRetry >= 15) {
-      clearInterval(_bootInterval);
-      DIAG.push('Boot: gave up waiting for elements after 30s');
-    } else {
-      // Re-attempt detect during SPA hydration
-      _cache.clear();
-    }
-  }, 2000);
-  Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8) });
-  console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}`);
-
-  /* v8.1.3: surface a PRIOR boot failure once, instead of it living silently
-     in GM storage forever. Reaching this line means boot succeeded THIS
-     time (the panel you're looking at is proof), so this only fires for a
-     failure on an earlier page load — e.g. a hardened page killed the whole
-     script before install() was made fault-tolerant. Visible in the
-     Diagnostics probe / any auto-report from here on, then cleared so it
-     doesn't repeat every boot. */
-  try {
+  _phase('prior-error-surface', false, () => {
+    /* Surface a PRIOR boot failure once (from GM storage), then clear it, so a
+       failure on an earlier load becomes visible in Diagnostics/reports now
+       that the panel is up. */
     const lastBoot = GM_getValue('lastBootError', '');
     const lastNet  = GM_getValue('lastNetInstallError', '');
     if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
     if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
-  } catch(_) {}
+  });
 
-  // Boot completed AND the panel is in the DOM — record success on the beacon.
-  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
-  // Panel self-heal: Gemini's Angular framework (and some other SPAs) can
-  // wipe document.body's children out from under us on route/re-render,
-  // silently removing #gitl with no error thrown — a leading suspect for
-  // "installed and active but nothing shows up" on Gemini specifically.
-  // Watch for the panel disappearing and re-mount it. Cheap: one observer,
-  // only acts when #gitl is actually gone.
-  try { startPanelWatchdog(); } catch(e) { DIAG.push('panel watchdog failed: ' + e); }
+  Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8), degraded: GHOST._degraded });
+  console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}` + (GHOST._degraded.length ? ` | degraded:${GHOST._degraded.join(',')}` : ''));
 });
 
-/* Re-mounts the panel if the page framework removes it from the DOM. */
-function startPanelWatchdog() {
-  let remounts = 0;
+/* PANEL SENTINEL (v8.2.0) — bounded, visibility-aware panel liveness.
+   Replaces the v8.1.4 watchdog, which only checked ABSENCE and had no cap, so
+   a page that re-hid the panel each time could drive an unbounded
+   append/remove storm. This version:
+     • treats the panel as "down" when it is disconnected, in a display:none /
+       visibility:hidden subtree, or has zero size (host may move #gitl into a
+       hidden container rather than remove it) — re-appending to document.body
+       rescues all of those. NOTE: safe because GITL never hides its OWN root
+       (collapsed state only hides the inner .g-body; the root keeps ≥44px);
+     • debounces, and CAPS remounts within a rolling window;
+     • on exceeding the cap, OPENS A CIRCUIT BREAKER: stops observing and shows
+       a visible, dismissible note instead of thrashing forever;
+     • disconnects observers/timers on teardown. */
+function startPanelSentinel() {
+  const MAX = 5, WINDOW_MS = 30000, DEBOUNCE_MS = 120;
+  let mo = null, poll = null, scheduled = null, opened = false;
+  const times = [];
+
+  const isDown = () => {
+    const n = document.getElementById('gitl');
+    if (!n || !n.isConnected || !document.body) return true;
+    try {
+      const st = getComputedStyle(n);
+      if (st.display === 'none' || st.visibility === 'hidden') return true;
+      const r = n.getBoundingClientRect();
+      if (r.width <= 2 && r.height <= 2) return true;
+    } catch(_) {}
+    return false;
+  };
+
+  const teardown = () => {
+    try { mo && mo.disconnect(); } catch(_) {}
+    if (poll) clearInterval(poll);
+    if (scheduled) clearTimeout(scheduled);
+    mo = poll = scheduled = null;
+  };
+
+  const openBreaker = () => {
+    opened = true;
+    teardown();
+    _beacon('sentinel-open');
+    Timeline.record('panel_circuit_open', { remounts: times.length, windowMs: WINDOW_MS });
+    try { DIAG.push('Panel sentinel opened: the page kept removing/hiding the panel — stopped re-mounting to avoid a loop.'); } catch(_) {}
+    // Visible, dismissible note (reuses the fatal-banner style, distinct id).
+    try {
+      if (document.getElementById('gitl-sentinel')) return;
+      const b = document.createElement('div');
+      b.id = 'gitl-sentinel';
+      b.setAttribute('style', 'position:fixed;top:0;left:0;right:0;z-index:2147483646;background:#2a230a;color:#ffe6a6;font:600 12px/1.4 system-ui,sans-serif;padding:9px 32px 9px 12px;border-bottom:2px solid #d9a441;white-space:pre-wrap');
+      b.textContent = "👻 Ghost's panel keeps being removed by this page, so it stopped re-adding it. Tap 🔄 re-detect or reload to try again.";
+      const x = document.createElement('span');
+      x.textContent = '×';
+      x.setAttribute('style', 'position:absolute;top:5px;right:10px;cursor:pointer;font-size:18px;line-height:1');
+      x.addEventListener('click', () => b.remove());
+      b.appendChild(x);
+      (document.body || document.documentElement).appendChild(b);
+    } catch(_) {}
+  };
+
   const ensure = () => {
-    if (document.getElementById('gitl') || !document.body) return;
-    // Panel vanished — re-append the SAME node (state/handlers intact).
+    if (opened || !isDown()) return;
+    const now = Date.now();
+    while (times.length && now - times[0] > WINDOW_MS) times.shift();
+    if (times.length >= MAX) { openBreaker(); return; }
+    times.push(now);
+    // Re-append the SAME node (state + event handlers intact).
     _panelMounted = false;
     mountPanel();
-    remounts++;
-    _beacon('remounted:' + remounts);
-    Timeline.record('panel_remount', { count: remounts });
-    DIAG.push('Panel was removed by the page — re-mounted (#' + remounts + ')');
+    _beacon('remounted:' + times.length);
+    Timeline.record('panel_remount', { count: times.length });
+    try { DIAG.push('Panel was removed/hidden by the page — re-mounted (#' + times.length + ')'); } catch(_) {}
     render();
   };
-  const mo = new MutationObserver(ensure);
+
+  const schedule = () => {
+    if (opened || scheduled) return;
+    scheduled = setTimeout(() => { scheduled = null; ensure(); }, DEBOUNCE_MS);
+  };
+
+  mo = new MutationObserver(schedule);
   mo.observe(document.documentElement, { childList: true, subtree: true });
-  // Belt-and-suspenders: a slow poll in case a body swap escapes the observer.
-  setInterval(ensure, 3000);
+  // Belt-and-suspenders: catch body swaps / CSS-only hides the observer may miss.
+  poll = setInterval(ensure, 3000);
 }
 
 } catch(__gitlBootErr) { _gitlFatal('top-level', __gitlBootErr); }

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -28,9 +28,51 @@ if (window.__GITL_V8__) return;
 window.__GITL_V8__ = true;
 
 /* ═══════════════════════════════════════════════════════════════
+   BOOT BEACON + FAIL-LOUD (v8.1.4)
+   The Gemini "panel never appears" reports were undiagnosable because a
+   silent top-level throw kills the whole script before the panel (which is
+   where all diagnostics live) can mount — so lastBootError was invisible.
+   Two dependency-free instruments that work even when nothing else does:
+     • a beacon written to <html data-gitl-boot="…"> at each phase, so it
+       shows up in a plain SingleFile/"save page" capture: `started` →
+       `ok:<ver>` on success, or `error:<stage>` if boot throws. This turns a
+       static page save into a real diagnosis of whether the script even ran.
+     • _gitlFatal(): on any fatal boot throw, surface it via GM_notification
+       AND a fixed banner injected at documentElement level (not body — body
+       may be the very thing that's missing/hostile), so the user can SEE and
+       screenshot the actual error instead of a blank page.
+   _gitlFatal is declared at IIFE scope (outside the try below) so it is
+   reachable from both the top-level catch and safeBoot's catch. */
+const _beacon = (s) => { try { document.documentElement.setAttribute('data-gitl-boot', s); } catch(_) {} };
+_beacon('started');
+function _gitlFatal(stage, err) {
+  const msg = String((err && (err.message || err)) || 'unknown');
+  const stack = String((err && err.stack) || '');
+  _beacon('error:' + stage);
+  try { GM_setValue('lastBootError', JSON.stringify({ stage, msg, stack, at: new Date().toISOString() })); } catch(_) {}
+  try { console.error('[GITL] FATAL @' + stage + ':', err); } catch(_) {}
+  try { if (typeof GM_notification === 'function') GM_notification({ title: '👻 Ghost failed to load (' + stage + ')', text: msg, timeout: 15000 }); } catch(_) {}
+  try {
+    if (document.getElementById('gitl-fatal')) return;
+    const b = document.createElement('div');
+    b.id = 'gitl-fatal';
+    b.setAttribute('style', 'position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#3a0d12;color:#ffd7dd;font:600 12px/1.4 system-ui,sans-serif;padding:10px 34px 10px 12px;border-bottom:2px solid #ff5570;box-shadow:0 4px 18px rgba(0,0,0,.5);white-space:pre-wrap;word-break:break-word');
+    b.textContent = '👻 Ghost in the Loop couldn’t start on this page (' + stage + ').\n' + msg + '\nScreenshot this and send it — it says exactly what broke.';
+    const x = document.createElement('span');
+    x.textContent = '×';
+    x.setAttribute('style', 'position:absolute;top:6px;right:10px;cursor:pointer;font-size:18px;line-height:1');
+    x.addEventListener('click', () => b.remove());
+    b.appendChild(x);
+    (document.body || document.documentElement).appendChild(b);
+  } catch(_) {}
+}
+
+try {
+
+/* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.3';
+const VER = '8.1.4';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -64,8 +106,9 @@ function safeBoot(fn) {
       if (!document.body) { requestAnimationFrame(boot); return; }
       fn();
     } catch (err) {
-      console.error('[GITL] boot failed:', err);
-      try { GM_setValue('lastBootError', JSON.stringify({ msg: String(err?.message||err), stack: String(err?.stack||''), at: new Date().toISOString() })); } catch(_){}
+      // v8.1.4: was silent (stored to GM only, invisible since the panel that
+      // shows it never mounted). Now fails loud via the same beacon+banner.
+      _gitlFatal('boot', err);
     }
   };
   if (document.readyState === 'loading') {
@@ -4503,6 +4546,38 @@ safeBoot(() => {
     if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
     if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
   } catch(_) {}
+
+  // Boot completed AND the panel is in the DOM — record success on the beacon.
+  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
+  // Panel self-heal: Gemini's Angular framework (and some other SPAs) can
+  // wipe document.body's children out from under us on route/re-render,
+  // silently removing #gitl with no error thrown — a leading suspect for
+  // "installed and active but nothing shows up" on Gemini specifically.
+  // Watch for the panel disappearing and re-mount it. Cheap: one observer,
+  // only acts when #gitl is actually gone.
+  try { startPanelWatchdog(); } catch(e) { DIAG.push('panel watchdog failed: ' + e); }
 });
+
+/* Re-mounts the panel if the page framework removes it from the DOM. */
+function startPanelWatchdog() {
+  let remounts = 0;
+  const ensure = () => {
+    if (document.getElementById('gitl') || !document.body) return;
+    // Panel vanished — re-append the SAME node (state/handlers intact).
+    _panelMounted = false;
+    mountPanel();
+    remounts++;
+    _beacon('remounted:' + remounts);
+    Timeline.record('panel_remount', { count: remounts });
+    DIAG.push('Panel was removed by the page — re-mounted (#' + remounts + ')');
+    render();
+  };
+  const mo = new MutationObserver(ensure);
+  mo.observe(document.documentElement, { childList: true, subtree: true });
+  // Belt-and-suspenders: a slow poll in case a body swap escapes the observer.
+  setInterval(ensure, 3000);
+}
+
+} catch(__gitlBootErr) { _gitlFatal('top-level', __gitlBootErr); }
 })();
 });

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -30,7 +30,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.0';
+const VER = '8.1.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -30,7 +30,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.0.0';
+const VER = '8.1.0';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -119,18 +119,60 @@ function startTabHeartbeat() {
   }, 5000);
 }
 
+/* ── Ticker (d12) ───────────────────────────────────────────────
+   Hidden tabs throttle setInterval to roughly once a minute, which stalls the
+   engine loop when you walk away. A Web Worker's timer is not throttled the
+   same way, so unattended runs tick from a Worker. Strict page CSP can refuse
+   blob: workers — in that case we transparently fall back to setInterval and
+   report which path is live (visible in Diagnostics). */
+const Ticker = {
+  _worker: null, _iv: null, mode: 'none',
+  start(fn, ms) {
+    this.stop();
+    if (unattendedOn() && typeof Worker !== 'undefined' && typeof Blob !== 'undefined') {
+      try {
+        const code = 'let i=null;onmessage=e=>{if(e.data&&e.data.cmd==="start"){if(i)clearInterval(i);i=setInterval(()=>postMessage("t"),e.data.ms);}else{clearInterval(i);i=null;}};';
+        const url = URL.createObjectURL(new Blob([code], { type: 'text/javascript' }));
+        this._worker = new Worker(url);
+        URL.revokeObjectURL(url);
+        this._worker.onmessage = () => { try { fn(); } catch(e) { DIAG.push('tick: ' + e.message); } };
+        this._worker.postMessage({ cmd: 'start', ms });
+        this.mode = 'worker';
+        DIAG.push('Unattended: Worker ticker active (background-throttle immune)');
+        return 'worker';
+      } catch (e) {
+        DIAG.push('Worker ticker blocked (page CSP) — using throttled timer: ' + e.message);
+        this._worker = null;
+      }
+    }
+    this._iv = setInterval(fn, ms);
+    this.mode = 'interval';
+    return 'interval';
+  },
+  stop() {
+    if (this._worker) { try { this._worker.postMessage({ cmd: 'stop' }); this._worker.terminate(); } catch(_) {} this._worker = null; }
+    if (this._iv) { clearInterval(this._iv); this._iv = null; }
+    this.mode = 'none';
+  }
+};
+
 /* Focus guard: prevents background tabs from burning tokens
    by auto-sending prompts while user isn't looking. */
+function unattendedOn() {
+  try { return !!(GHOST && GHOST.ui && GHOST.ui.unattended); } catch(_) { return false; }
+}
 function isTabSafeToAct() {
-  if (!document.hasFocus()) return false;
-  if (document.hidden) return false;
-  return claimTabLock();
+  if (!unattendedOn()) {
+    if (!document.hasFocus()) return false;
+    if (document.hidden) return false;
+  }
+  return claimTabLock();   // multi-tab collision guard is NEVER relaxed
 }
 
 /* Pre-send safety gate: called before every engineSend.
    Returns { ok, reason } */
 function assertInteractionSafe() {
-  if (!document.hasFocus() && typeof GHOST !== 'undefined' && GHOST.loop.state === 'RUNNING') {
+  if (!unattendedOn() && !document.hasFocus() && typeof GHOST !== 'undefined' && GHOST.loop.state === 'RUNNING') {
     return { ok: false, reason: 'tab-not-focused' };
   }
   if (!claimTabLock()) {
@@ -153,12 +195,21 @@ if (typeof window !== 'undefined') {
    the DOM. Supplements DOM-based detection — does NOT replace it.
    Sources: Gemini Phase 0, Kimi Deep Dive, DeepSeek cascade
    ═══════════════════════════════════════════════════════════════ */
+/* Page-world handle: with GM grants the script runs sandboxed, so patching
+   the sandbox's window.fetch never sees the site's own requests. unsafeWindow
+   is the page's real window (Firefox MV3 port: inject in world:"MAIN"). */
+const UW = (typeof unsafeWindow !== 'undefined' && unsafeWindow) ? unsafeWindow : window;
+
 const GITL_NET = {
   bus: new EventTarget(),
   lastChunk: '',
   lastComplete: '',
   capturedAt: 0,
-  active: false,
+  active: false,        // interceptor installed (kept for health snapshot compat)
+  lastPulseT: 0,        // last traffic on a KNOWN chat endpoint (trusted)
+  lastPulseH: 0,        // last traffic on a heuristic same-origin stream
+  _open: 0,             // streams currently open
+  expectUntil: 0,       // set by _onSendOk: window in which heuristic pulses count
 
   AI_ENDPOINTS: [
     '/backend-api/conversation',   // ChatGPT
@@ -167,7 +218,8 @@ const GITL_NET = {
     '/api/v1/chat/completions',    // DeepSeek / OpenAI-compat
     '/chat/conversation',          // HuggingChat
     '/api/chat',                   // Generic
-    '/bard',                       // Gemini
+    '/bard',                       // Gemini (legacy)
+    'batchexecute',                // Gemini (current streaming transport)
     '/turn/',                      // Copilot
   ],
 
@@ -177,10 +229,41 @@ const GITL_NET = {
     return this.AI_ENDPOINTS.some(ep => s.includes(ep));
   },
 
+  _pulse(trusted) {
+    const t = Date.now();
+    if (trusted) this.lastPulseT = t; else this.lastPulseH = t;
+  },
+
+  /* Same-origin streams that LOOK like chat traffic even when the endpoint
+     isn't in AI_ENDPOINTS — the platform-proof fallback when sites reshuffle
+     their APIs. Analytics-ish URLs are excluded. */
+  _maybeChat(url, method) {
+    try {
+      const s = typeof url === 'string' ? url : (url && url.url) || String(url || '');
+      if (!s) return false;
+      const sameOrigin = s.startsWith('/') || s.includes(location.hostname);
+      if (!sameOrigin) return false;
+      if (/log|telemetry|beacon|analytics|sentry|metric|track|collect|report/i.test(s)) return false;
+      return String(method || 'GET').toUpperCase() === 'POST';
+    } catch(_) { return false; }
+  },
+
+  /* True while generation traffic is plausibly flowing.
+     Trusted (known-endpoint) pulses always count; heuristic pulses only count
+     inside the post-send expectation window, so a random background stream
+     can't convince the engine that a reply is being written. */
+  streaming() {
+    const now = Date.now();
+    if (now - this.lastPulseT < 1500) return true;
+    if (now < this.expectUntil && (this._open > 0 || now - this.lastPulseH < 1500)) return true;
+    return false;
+  },
+
   _emit(raw, isDone) {
     if (raw === '[DONE]') isDone = true;
     this.lastChunk = raw;
     this.capturedAt = Date.now();
+    this._pulse(true);
     if (isDone) this.lastComplete = raw;
     this.bus.dispatchEvent(new CustomEvent('gitl:net', {
       detail: { raw, isDone, ts: Date.now() }
@@ -191,12 +274,35 @@ const GITL_NET = {
     if (this.active) return;
     this.active = true;
 
-    /* Fetch proxy — captures SSE / JSON streams */
-    const origFetch = window.fetch;
+    /* Fetch proxy on the PAGE window — captures SSE / JSON streams */
     const self = this;
-    window.fetch = async function(...args) {
+    const origFetch = UW.fetch;
+    if (typeof origFetch === 'function') UW.fetch = async function(...args) {
       const response = await origFetch.apply(this, args);
-      if (self._isChat(args[0])) {
+      const listed = self._isChat(args[0]);
+      let heur = false;
+      if (!listed) {
+        try {
+          const ct = response.headers && response.headers.get && (response.headers.get('content-type') || '');
+          heur = ct.includes('event-stream') || self._maybeChat(args[0], args[1] && args[1].method);
+        } catch(_) {}
+      }
+      if (heur) {
+        /* Heuristic path: timestamps only — content is never read or stored. */
+        try {
+          const cloned = response.clone();
+          if (cloned.body) {
+            const reader = cloned.body.getReader();
+            self._open++; self._pulse(false);
+            (async () => {
+              try { while (true) { const { done } = await reader.read(); self._pulse(false); if (done) break; } }
+              catch(_) {}
+              finally { self._open = Math.max(0, self._open - 1); }
+            })();
+          }
+        } catch(_) {}
+      }
+      if (listed) {
         try {
           const cloned = response.clone();
           if (cloned.body) {
@@ -228,23 +334,44 @@ const GITL_NET = {
       return response;
     };
 
-    /* XHR proxy — fallback for platforms not using fetch */
-    const origOpen = XMLHttpRequest.prototype.open;
-    XMLHttpRequest.prototype.open = function(method, url, ...rest) {
-      this._gitlUrl = url;
-      return origOpen.call(this, method, url, ...rest);
-    };
-    const origSend = XMLHttpRequest.prototype.send;
-    XMLHttpRequest.prototype.send = function(...args) {
-      if (self._isChat(this._gitlUrl)) {
-        this.addEventListener('load', function() {
-          if (this.status >= 200 && this.status < 300 && this.responseText) {
-            self._emit(this.responseText, true);
+    /* XHR proxy on the PAGE window — Gemini streams via batchexecute XHRs */
+    const XP = (UW.XMLHttpRequest && UW.XMLHttpRequest.prototype) || null;
+    if (XP && XP.open && XP.send) {
+      const origOpen = XP.open;
+      XP.open = function(method, url, ...rest) {
+        this._gitlUrl = url; this._gitlMethod = method;
+        return origOpen.call(this, method, url, ...rest);
+      };
+      const origSend = XP.send;
+      XP.send = function(...args) {
+        const listed = self._isChat(this._gitlUrl);
+        const heur = !listed && self._maybeChat(this._gitlUrl, this._gitlMethod);
+        if (listed || heur) {
+          try {
+            this.addEventListener('loadstart', () => { self._open++; self._pulse(listed); });
+            this.addEventListener('progress',  () => self._pulse(listed));
+            this.addEventListener('loadend',   () => { self._open = Math.max(0, self._open - 1); self._pulse(listed); });
+            if (listed) this.addEventListener('load', function() {
+              if (this.status >= 200 && this.status < 300 && this.responseText) self._emit(this.responseText, true);
+            });
+          } catch(_) {}
+        }
+        return origSend.apply(this, args);
+      };
+    }
+
+    /* WebSocket pulse — Perplexity's socket.io traffic (timestamps only) */
+    try {
+      if (typeof UW.WebSocket === 'function') {
+        UW.WebSocket = new Proxy(UW.WebSocket, {
+          construct(T, a) {
+            const ws = new T(...a);
+            try { ws.addEventListener('message', () => self._pulse(self._isChat(a[0]))); } catch(_) {}
+            return ws;
           }
         });
       }
-      return origSend.apply(this, args);
-    };
+    } catch(_) {}
 
     console.log('[GITL] Network interceptor active');
   }
@@ -261,19 +388,20 @@ const PROFILES = {
   chatgpt: {
     host: /chatgpt\.com|chat\.openai\.com/,
     label: 'ChatGPT',
-    input: ['#prompt-textarea','div[contenteditable="true"][id="prompt-textarea"]','textarea[data-id="root"]','textarea'],
-    send: ['button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[class*="send"]'],
-    stop: ['button[aria-label="Stop generating"]','button[data-testid="stop-button"]'],
-    assistant: ['div[data-message-author-role="assistant"]','article [data-message-author-role="assistant"]'],
+    input: ['#prompt-textarea','div[contenteditable="true"][id="prompt-textarea"]','div[contenteditable="true"][data-placeholder]','textarea[data-id="root"]','textarea'],
+    send: ['button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[data-testid*="send"]','button[data-testid*="submit"]','button[class*="send"]'],
+    stop: ['button[aria-label="Stop generating"]','button[data-testid="stop-button"]','button[aria-label*="Stop"]','button[data-testid*="stop"]'],
+    assistant: ['div[data-message-author-role="assistant"]','article [data-message-author-role="assistant"]','div[data-testid^="conversation-turn"] div[data-message-author-role="assistant"]'],
     continueLabels: ['Continue generating','Continue'],
     useCE: false, useNS: true
   },
   perplexity: {
     host: /perplexity\.ai/,
     label: 'Perplexity',
-    input: ['textarea[placeholder*="Ask"]','textarea[placeholder*="Follow"]','div[contenteditable="true"][role="textbox"]','div[class*="ProseMirror"]','textarea:not([disabled])'],
+    input: ['textarea[placeholder*="Ask"]','textarea[placeholder*="Follow"]','div[contenteditable="true"][role="textbox"]','div[class*="ProseMirror"]','[data-testid="composer"]','textarea:not([disabled])'],
     send: ['button[aria-label="Submit"]','button[aria-label="Send"]','button[type="submit"]'],
-    stop: ['button[aria-label="Stop"]','[data-testid="stop-button"]'],
+    stop: ['button[aria-label="Stop"]','button[aria-label*="Stop"]','[data-testid="stop-button"]','button[data-testid*="stop"]'],
+    staleTicks: 24,   // Deep Research thinks for minutes with no DOM growth and no stop button
     assistant: ['div[class*="prose"]','div[dir="auto"][class*="break-words"]','.pb-md > div'],
     continueLabels: [],
     useCE: true, useNS: false
@@ -281,10 +409,10 @@ const PROFILES = {
   gemini: {
     host: /gemini\.google\.com/,
     label: 'Gemini',
-    input: ['div.ql-editor[contenteditable="true"]','rich-textarea div[contenteditable="true"]','div[contenteditable="true"]','textarea'],
-    send: ['button[aria-label="Send message"]','button[aria-label*="Send"]','button.send-button'],
-    stop: ['button[aria-label*="Stop"]'],
-    assistant: ['model-response message-content','message-content','div[class*="model-response"]'],
+    input: ['rich-textarea .ql-editor[contenteditable="true"]','div.ql-editor[contenteditable="true"]','rich-textarea div[contenteditable="true"]','div[role="textbox"][contenteditable="true"]','div[contenteditable="true"]','textarea'],
+    send: ['button[aria-label="Send message"]','button[aria-label*="Send"]','button.send-button','button[data-test-id="send-button"]'],
+    stop: ['button[aria-label*="Stop"]','button[aria-label*="stop"]'],
+    assistant: ['model-response message-content','model-response .message-content','model-response','div[class*="model-response"]','message-content'],
     continueLabels: [],
     useCE: true, useNS: false
   },
@@ -311,10 +439,10 @@ const PROFILES = {
   grok: {
     host: /grok\.com/,
     label: 'Grok',
-    input: ['textarea[placeholder*="Ask"]','textarea','div[contenteditable="true"]'],
-    send: ['button[aria-label="Send"]','button[type="submit"]'],
-    stop: ['button[aria-label="Stop"]'],
-    assistant: ['div[class*="message"][class*="bot"]','div[data-role="assistant"]'],
+    input: ['textarea[aria-label="Ask Grok anything"]','textarea[placeholder*="Grok"]','textarea[placeholder*="Ask"]','textarea[data-testid="grok-compose-input"]','div[contenteditable="true"][data-lexical-editor="true"]','div[contenteditable="true"]','textarea'],
+    send: ['button[aria-label="Submit"]','button[aria-label="Send message"]','button[aria-label*="Send"]','button[data-testid="send-button"]','button[data-testid*="submit"]','button[type="submit"]','button.send-button'],
+    stop: ['button[aria-label="Stop"]','button[aria-label*="stop"]'],
+    assistant: ['div[class*="message"][class*="bot"]','div[data-role="assistant"]','div[class*="response"]'],
     continueLabels: [],
     useCE: false, useNS: false
   },
@@ -452,13 +580,209 @@ function _qAll(sels) {
   return results;
 }
 
+/* ── Heuristic finders (final fallback tier) ─────────────────────
+   When a site redesign breaks every configured selector, these locate the
+   composer and send button by ROLE and MEANING instead of class names —
+   the Playwright-style aria/text-first strategy. Engaged only when the
+   selector arrays come up empty, so normal operation is unchanged. */
+const SEND_WORDS = /send|submit|发送|傳送|送信|보내기|enviar|envoyer|senden|invia|отправ|إرسال|gönder/i;
+/* v8.1: veto list expanded after the DeepSeek incident — the heuristic tier
+   clicked the reply's "Copy" button (svg icon + proximity alone scored past
+   the old threshold) and the user's prompt got copied instead of sent.
+   Message-action verbs are now hard-vetoed on EVERY send tier. */
+const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research/i;
+
+/* A candidate send control must clear the veto no matter which tier found
+   it — configured selectors can rot into matching the wrong control after
+   a site redesign (e.g. div[class*="send"] matching a share widget). */
+function _sendLooksSafe(el) {
+  if (!el) return false;
+  try {
+    const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
+                   el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
+    return !SEND_VETO.test(label);
+  } catch(_) { return true; }
+}
+
+function _visible(el) {
+  try {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && r.bottom > 0 && r.top < innerHeight;
+  } catch(_) { return false; }
+}
+
+const _heurCache = { input:{el:null,ts:0}, send:{el:null,ts:0} };
+let _heurNoteTs = 0;
+function _heurNote(what) {
+  if (Date.now() - _heurNoteTs < 60000) return;
+  _heurNoteTs = Date.now();
+  DIAG.push('Heuristic ' + what + ' engaged — configured selectors failed');
+}
+
+function _heurInput() {
+  const c = _heurCache.input;
+  if (c.el && c.el.isConnected && Date.now() - c.ts < 4000) return c.el;
+  let best = null, bestScore = 3;
+  for (const el of _qAll(['textarea:not([disabled])','div[contenteditable="true"]'])) {
+    if (!_visible(el)) continue;
+    let s = 0;
+    const r = el.getBoundingClientRect();
+    if (el.getAttribute('role') === 'textbox' || el.getAttribute('aria-label')) s += 3;
+    if (r.top > innerHeight * 0.4) s += 2;
+    s += Math.min(2, (r.width * r.height) / 50000);
+    if (/ProseMirror|ql-editor/.test(String(el.className || ''))) s += 2;
+    if (s > bestScore) { bestScore = s; best = el; }
+  }
+  if (best) { _heurNote('input finder'); _heurCache.input.el = best; _heurCache.input.ts = Date.now(); }
+  return best;
+}
+
+function _heurSend(anchor) {
+  const c = _heurCache.send;
+  if (c.el && c.el.isConnected && !c.el.disabled && Date.now() - c.ts < 4000) return c.el;
+  let best = null, bestScore = 3.5;
+  const ar = anchor && anchor.getBoundingClientRect ? anchor.getBoundingClientRect() : null;
+  const aForm = anchor && anchor.closest ? anchor.closest('form') : null;
+  for (const el of _qAll(['button','[role="button"]'])) {
+    if (!_visible(el) || el.disabled || el.getAttribute('aria-disabled') === 'true') continue;
+    const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
+                   el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
+    if (SEND_VETO.test(label)) continue; // hard veto — a wrong click (mic, attach) is worse than no click
+    /* v8.1 semantic gate: proximity + an svg icon must NEVER be enough on
+       their own (that combination is every message-action button on the
+       page). A candidate needs at least one POSITIVE send signal. */
+    const sem = SEND_WORDS.test(label)
+             || (el.getAttribute('type') || '') === 'submit'
+             || (aForm && el.closest && el.closest('form') === aForm);
+    if (!sem) continue;
+    let s = 0;
+    if (SEND_WORDS.test(label)) s += 4;
+    if ((el.getAttribute('type') || '') === 'submit') s += 2;
+    if (el.querySelector && el.querySelector('svg') && (el.textContent || '').trim().length < 2) s += 1;
+    if (aForm && el.closest && el.closest('form') === aForm) s += 3;
+    if (ar) {
+      const r = el.getBoundingClientRect();
+      const d = Math.hypot((r.left + r.width/2) - (ar.left + ar.width/2),
+                           (r.top + r.height/2) - (ar.top + ar.height/2));
+      if (d < 320) s += 3;
+    }
+    if (s > bestScore) { bestScore = s; best = el; }
+  }
+  if (best) { _heurNote('send-button finder'); _heurCache.send.el = best; _heurCache.send.ts = Date.now(); }
+  return best;
+}
+
+/* ── SELECTOR MEMORY (v8.1) — self-healing learned locators ──────
+   Healenium-style: when the configured selectors fail but the heuristic
+   tier finds the element, derive a STABLE selector from the found node
+   (id > data-testid > aria-label > name > placeholder > role) and persist
+   it per-host. Next time — including after a reload — the learned selector
+   is tried right after the configured ones, so a site redesign pays the
+   heuristic cost once and the fix survives sessions. Capped + self-pruning. */
+const SelectorMemory = {
+  key: 'gitlLearnedSelectors',
+  MAX_HOSTS: 12,
+  _data: null,
+
+  _load() {
+    if (this._data) return this._data;
+    try { this._data = JSON.parse(GM_getValue(this.key, '{}')) || {}; } catch(_) { this._data = {}; }
+    return this._data;
+  },
+  _persist() { try { GM_setValue(this.key, JSON.stringify(this._data)); } catch(_){} },
+
+  /* Derive a stable selector that uniquely matches el right now, or null. */
+  derive(el) {
+    if (!el || !el.getAttribute) return null;
+    const esc = (s) => (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(s) : String(s).replace(/([^\w-])/g, '\\$1');
+    const tag = (el.tagName || '').toLowerCase();
+    const cands = [];
+    const id = el.getAttribute('id');
+    if (id) cands.push(`#${esc(id)}`);
+    for (const a of ['data-testid','data-test-id','aria-label','name','placeholder','data-placeholder']) {
+      const v = el.getAttribute(a);
+      if (v && v.length <= 80) cands.push(`${tag}[${a}="${v.replace(/\\/g,'\\\\').replace(/"/g,'\\"')}"]`);
+    }
+    const role = el.getAttribute('role');
+    if (role && el.getAttribute('contenteditable') === 'true') cands.push(`${tag}[contenteditable="true"][role="${role}"]`);
+    for (const sel of cands) {
+      try { const m = document.querySelectorAll(sel); if (m.length === 1 && m[0] === el) return sel; } catch(_){}
+    }
+    return null;
+  },
+
+  learn(kind, el) {
+    const sel = this.derive(el);
+    if (!sel) return null;
+    const d = this._load(), h = location.hostname;
+    d[h] = d[h] || {};
+    const prev = d[h][kind];
+    d[h][kind] = { sel, at: Date.now() };
+    // Prune least-recently-touched hosts beyond the cap.
+    const hosts = Object.keys(d);
+    if (hosts.length > this.MAX_HOSTS) {
+      hosts.sort((a, b) =>
+        Math.max(0, ...Object.values(d[a]).map(x => x.at || 0)) -
+        Math.max(0, ...Object.values(d[b]).map(x => x.at || 0)));
+      while (hosts.length > this.MAX_HOSTS) delete d[hosts.shift()];
+    }
+    this._persist();
+    if (!prev || prev.sel !== sel) {
+      try { DIAG.push(`Learned ${kind} selector: ${sel}`); } catch(_){}
+      try { Timeline.record('selector_learned', { kind, sel }); } catch(_){}
+    }
+    return sel;
+  },
+
+  lookup(kind) {
+    const rec = this._load()[location.hostname]?.[kind];
+    if (!rec || !rec.sel) return null;
+    try {
+      for (const el of document.querySelectorAll(rec.sel)) {
+        if (el && !_isOwnUI(el) && _visible(el)) {
+          if (kind === 'send' && !_sendLooksSafe(el)) { this.forget(kind); return null; }
+          return el;
+        }
+      }
+    } catch(_) { this.forget(kind); }
+    return null;
+  },
+
+  forget(kind) {
+    const d = this._load(), h = location.hostname;
+    if (d[h] && d[h][kind]) {
+      delete d[h][kind];
+      if (!Object.keys(d[h]).length) delete d[h];
+      this._persist();
+    }
+  }
+};
+
 // Adapter — all DOM reads/writes
 const Adapter = {
-  getInput()      { return _q('in', PLAT.input); },
-  getSendBtn()    { return _q('send', PLAT.send); },
-  isGenerating()  { return !!_q('gen', PLAT.stop); },
+  getInput() {
+    let el = _q('in', PLAT.input) || SelectorMemory.lookup('input');
+    if (!el) { el = _heurInput(); if (el) SelectorMemory.learn('input', el); }
+    return el;
+  },
+  getSendBtn() {
+    // Every tier passes through the veto — a stale configured selector must
+    // never hand back a Copy/Share/Download control (DeepSeek incident).
+    const b = _q('send', PLAT.send);
+    if (b && !b.disabled && _sendLooksSafe(b)) return b;
+    const learned = SelectorMemory.lookup('send');
+    if (learned && !learned.disabled) return learned;
+    const h = _heurSend(this.getInput() || null);
+    if (h) { SelectorMemory.learn('send', h); return h; }
+    return (b && _sendLooksSafe(b)) ? b : null;
+  },
+  isGenerating()  { return !!_q('gen', PLAT.stop) || GITL_NET.streaming(); },
   hasMessages()   { return _qAll(PLAT.assistant).length > 0; },
   getLastText() {
+    // Gemini only: virtual scroll — nudge infinite-scroller to bottom
+    if (PLAT && PLAT.key === 'gemini') {
+      try { const s = document.querySelector('infinite-scroller'); if (s) s.scrollTop = s.scrollHeight; } catch(_){}
+    }
     const els = _qAll(PLAT.assistant);
     return els.length ? (els[els.length-1].innerText || '').trim() : '';
   },
@@ -477,10 +801,26 @@ const Adapter = {
       // FIX: selectAll+insertText preserves ProseMirror state (innerHTML='' destroys it)
       document.execCommand('selectAll', false, null);
       const ok = document.execCommand('insertText', false, text);
-      if (!ok) { el.textContent = text; }
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-      el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
-      DIAG.sendPath = 'contenteditable';
+      if (!ok) {
+        // execCommand unavailable — fall back with proper InputEvent
+        el.textContent = text;
+        el.dispatchEvent(new InputEvent('input', { inputType:'insertText', data:text, bubbles:true, cancelable:true, composed:true }));
+      } else {
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      // Paste tier: some editors (Lexical builds) ignore both paths above.
+      if ((el.textContent || '').indexOf(text.slice(0, 24)) === -1) {
+        try {
+          if (typeof DataTransfer !== 'undefined' && typeof ClipboardEvent !== 'undefined') {
+            const dt = new DataTransfer();
+            dt.setData('text/plain', text);
+            el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true, composed: true }));
+            DIAG.sendPath = 'ce-paste';
+          }
+        } catch(_) {}
+      }
+      el.dispatchEvent(new InputEvent('input', { bubbles:true, inputType:'insertText', data:text, composed:true }));
+      if (DIAG.sendPath !== 'ce-paste') DIAG.sendPath = 'contenteditable';
       return true;
     }
     // Path 2: native React setter
@@ -496,8 +836,11 @@ const Adapter = {
     return true;
   },
   pressEnter(el) {
+    // Stage A: insertParagraph beforeinput — ProseMirror/Lexical native submit signal
+    try { el.dispatchEvent(new InputEvent('beforeinput', { inputType:'insertParagraph', bubbles:true, cancelable:true, composed:true })); } catch(_){}
+    // Stage B: keyboard Enter with composed:true — crosses Shadow DOM boundaries
     ['keydown','keypress','keyup'].forEach(t => {
-      el.dispatchEvent(new KeyboardEvent(t, { key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true }));
+      el.dispatchEvent(new KeyboardEvent(t, { key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true, composed:true }));
     });
   }
 };
@@ -520,10 +863,40 @@ const PERSONA_LIBRARY = {
 // Perplexity (and any model-switcher) variant — a REAL round table across models, not a simulated one.
 const ROUNDTABLE_LIVE = 'This is a live multi-model round table. The operator switches the active model between turns using the model selector. You are ONE lens at this table. Give your OWN independent assessment of the work so far — do NOT simply agree with or extend the previous model. Challenge assumptions, fill gaps, add what only you would add. Put all substantive output in a single code block, no fluff, so it carries cleanly to the next model. End with one line naming which model should take the next turn and why, then [[GITL::PROCEED]] — or [[GITL::HALT]] only if genuine consensus is reached.';
 
+/* The full context block for a run: who the model is (persona/committee),
+   how it should think (posture), and how it should work (strategy).
+   `includeStrategy` is false on roadmap resumes — re-sending the roadmap
+   payload mid-run would ask for a brand-new roadmap. */
+function runDirectives(includeStrategy = true) {
+  const L = GHOST.loop;
+  const persona = resolvePersonaInject();
+  const posture = POSTURES[L.posture] || POSTURES.standard;
+  let out = '';
+  if (persona) out += `\n\n[Active persona]\n${persona}`;
+  if (includeStrategy && PAYLOADS[L.payloadMode]) out += PAYLOADS[L.payloadMode].inject;
+  out += posture.clause + (L.posture === 'standard' ? '' : POSTURE_CEILING);
+  return out;
+}
+function hasPendingDirectives() {
+  return !GHOST.persona._delivered && !!resolvePersonaInject();
+}
+
 function resolvePersonaInject() {
-  const sel = GHOST.persona.selected;
-  if (sel === 'roundtable' && /Perplexity/i.test(PLAT.label)) return ROUNDTABLE_LIVE;
-  return allPersonas()[sel]?.inject || '';
+  let sel = GHOST.persona.selected;
+  if (typeof sel === 'string') sel = [sel];
+  if (!Array.isArray(sel)) sel = ['none'];
+  const active = sel.filter(s => s && s !== 'none');
+  if (!active.length) return '';
+  // Special: live Perplexity round table is a protocol, not composable
+  if (active.includes('roundtable') && /Perplexity/i.test(PLAT.label)) return ROUNDTABLE_LIVE;
+  // Single persona — classic behavior
+  if (active.length === 1) return allPersonas()[active[0]]?.inject || '';
+  // Committee: concatenate perspectives with framing
+  const personas = active.map(s => allPersonas()[s]).filter(Boolean);
+  if (!personas.length) return '';
+  const names = personas.map(p => p.label).join(', ');
+  const injects = personas.map(p => `• ${p.label}: ${p.inject}`).join('\n');
+  return `You are operating as a committee of ${active.length} expert perspectives: ${names}.\nFor each task or decision point, give each perspective's independent assessment, then synthesize a stronger consensus with disagreements preserved.\n\nThe perspectives:\n${injects}`;
 }
 
 const WORKFLOW_LIBRARY = {
@@ -635,14 +1008,44 @@ const Workshop = {
 
   // ── Export: combined bundle of custom items only ──
   exportBundle() {
-    return JSON.stringify({
+    const out = {
       schema: WORKSHOP_SCHEMA,
       tool: 'Ghost in the Loop',
       version: VER,
       exported: new Date().toISOString(),
       personas:  Object.entries(this.personas).map(([id,p])  => ({ id, label: p.label, inject: p.inject })),
       workflows: Object.entries(this.workflows).map(([id,w]) => ({ id, label: w.label, desc: w.desc, stages: w.stages }))
-    }, null, 2);
+    };
+    // v8.1: the active custom skin rides along (validated tokens only), so a
+    // single .gitl.json can share a complete look-and-brains pack.
+    try {
+      if (typeof SKIN !== 'undefined' && typeof GHOST !== 'undefined'
+          && GHOST.ui.skinTheme === 'custom' && GHOST.ui.customSkin) {
+        const r = SKIN.validate(GHOST.ui.customSkin);
+        if (r.ok) out.skin = r.skin;
+      }
+    } catch(_) {}
+    return JSON.stringify(out, null, 2);
+  },
+
+  // ── Share (v8.1): paste-ready markdown post for GitHub Discussions ──
+  shareText() {
+    const nP = Object.keys(this.personas).length;
+    const nW = Object.keys(this.workflows).length;
+    const items = [
+      ...Object.values(this.personas).map(p => `- 👤 ${p.label}`),
+      ...Object.values(this.workflows).map(w => `- ⛓ ${w.label} (${(w.stages||[]).length} stages)`)
+    ];
+    let skinLine = '';
+    try {
+      if (typeof GHOST !== 'undefined' && GHOST.ui.skinTheme === 'custom' && GHOST.ui.customSkin) {
+        const nm = JSON.parse(GHOST.ui.customSkin).name || 'custom';
+        items.push(`- 🎨 Skin: ${nm}`);
+        skinLine = ', 1 skin';
+      }
+    } catch(_) {}
+    const title = (typeof GHOST !== 'undefined' && GHOST.project.name) ? GHOST.project.name : 'My GITL pack';
+    return `## Workshop pack: ${title}\n\n**Contains:** ${nP} persona(s), ${nW} workflow(s)${skinLine}\n\n${items.join('\n')}\n\nTo use: save the JSON below as \`pack.gitl.json\`, then **⬆ Import** in Ghost's Workshop.\n\n\`\`\`json\n${this.exportBundle()}\n\`\`\`\n`;
   },
 
   // ── Import: additive, protects built-ins, auto-renames custom clashes ──
@@ -655,7 +1058,8 @@ const Workshop = {
     if (data.schema && !String(data.schema).startsWith('gitl-workshop/')) return { ok:false, error:'Not a Ghost Workshop file' };
     const inP = Array.isArray(data.personas)  ? data.personas  : [];
     const inW = Array.isArray(data.workflows) ? data.workflows : [];
-    if (inP.length + inW.length === 0) return { ok:false, error:'No personas or workflows in file' };
+    const hasSkin = data.skin && typeof data.skin === 'object';
+    if (inP.length + inW.length === 0 && !hasSkin) return { ok:false, error:'No personas, workflows, or skin in file' };
     if (inP.length + inW.length > WORKSHOP_LIMITS.maxItems) return { ok:false, error:`Too many items (max ${WORKSHOP_LIMITS.maxItems})` };
     const res = { ok:true, personas:0, workflows:0, skipped:0, renamed:0 };
     const pTaken = new Set([...Object.keys(PERSONA_LIBRARY), ...Object.keys(this.personas)]);
@@ -679,6 +1083,24 @@ const Workshop = {
         stages: w.stages.map(s => String(s).trim().slice(0,WORKSHOP_LIMITS.stage)).slice(0,WORKSHOP_LIMITS.stages), custom: true };
       res.workflows++;
     }
+    // v8.1: optional bundled skin — validated by the skin whitelist, applied
+    // as the custom skin. Invalid skins are skipped, never fatal.
+    res.skin = 0;
+    if (hasSkin) {
+      try {
+        if (typeof SKIN !== 'undefined') {
+          const r = SKIN.validate(JSON.stringify(data.skin));
+          if (r.ok && typeof GHOST !== 'undefined') {
+            GHOST.ui.customSkin = JSON.stringify(r.skin);
+            GHOST.ui.skinTheme = 'custom';
+            _save('customSkin', GHOST.ui.customSkin);
+            _save('skinTheme', 'custom');
+            SKIN.apply();
+            res.skin = 1;
+          } else { res.skipped++; }
+        }
+      } catch(_) { res.skipped++; }
+    }
     this._persist();
     return res;
   }
@@ -698,7 +1120,14 @@ const GHOST = {
     pauseBetween: GM_getValue('wfPause',false),
     active: false
   },
-  persona: { selected: GM_getValue('persona','none') },
+  persona: {
+    selected: (()=>{ const raw=GM_getValue('persona','none'); try { const p=JSON.parse(raw); return Array.isArray(p)?p:[raw]; } catch(_){ return [typeof raw==='string'?raw:'none']; } })(),
+    committee: GM_getValue('personaCommittee',false),
+    _delivered: false,  // runtime: have this run's directives reached the model yet?
+    perTask: GM_getValue('personaPerTask',false),
+    finalReview: GM_getValue('personaFinalReview',false),
+    _reviewDone: false
+  },
   roadmap: {
     steps: JSON.parse(GM_getValue('rmSteps','[]')),
     index: GM_getValue('rmIndex',0),
@@ -715,6 +1144,7 @@ const GHOST = {
     needsPayload: true,
     isSending: false,
     timer: null,
+    driftEnabled: GM_getValue('driftEnabled',true),
     lastActivity: Date.now(),
     staleTicks: 0,
     lastSignal: 'none',
@@ -748,12 +1178,18 @@ const GHOST = {
     soundOn: GM_getValue('soundOn',true),
     notifyOn: GM_getValue('notifyOn',false),
     cfgAdv: GM_getValue('cfgAdv',false),
+    unattended: GM_getValue('unattended',false), // relax the focus guard + use a Worker ticker
+    explain: false, // runtime-only: tap-ⓘ-then-tap-anything help mode
     helpSec: 'start',
     prevTab: null,
     wsNewPersona: false,
     wsNewWorkflow: false,
     qDraft: (()=>{ try { const a = JSON.parse(GM_getValue('qDraft','[""]')); return Array.isArray(a)&&a.length?a:['']; } catch(_){ return ['']; } })(),
     expAdv: GM_getValue('expAdv',false),
+    skinTheme: (v => v==='new' ? 'aurora' : v)(GM_getValue('skinTheme','classic')),
+    customSkin: GM_getValue('customSkin',''),
+    accentHue: (v => (v===''||v==null) ? NaN : parseInt(v,10))(GM_getValue('accentHue','')),
+    runAdv: false,
     showDiag: false,
     showSites: false,
     firstRun: GM_getValue('firstRun',true)
@@ -790,6 +1226,16 @@ const DIAG = {
       }
       out.push(n ? `✓ ${k}: ${win} (${n})` : `✗ ${k}: NO MATCH`);
     }
+    // Fallback tiers (v8.1): learned per-host selectors, then role/meaning heuristics.
+    try {
+      const lm = (typeof SelectorMemory !== 'undefined') ? SelectorMemory._load()[location.hostname] : null;
+      out.push(lm ? `✓ learned: ${Object.entries(lm).map(([k,v]) => k + '=' + v.sel).join(' · ')}` : '— learned: none for this host');
+    } catch(_) {}
+    try {
+      const hi = _heurInput(), hs = _heurSend(hi || null);
+      out.push(hi ? `✓ heur input: <${(hi.tagName||'?').toLowerCase()}>` : '✗ heur input: none');
+      out.push(hs ? `✓ heur send: <${(hs.tagName||'?').toLowerCase()}> "${String(hs.getAttribute && (hs.getAttribute('aria-label')||hs.textContent)||'').trim().slice(0,30)}"` : '✗ heur send: none');
+    } catch(_) {}
     this.probe = out.join('\n');
   }
 };
@@ -815,6 +1261,7 @@ function platformHealth() {
     assistantCount: msgs.length, ready: canInject && canSend,
     badge: score >= 80 ? '🟢' : score >= 40 ? '🟡' : '🔴',
     netActive: GITL_NET.active,
+    netStreaming: GITL_NET.streaming(),
     netAge: GITL_NET.capturedAt ? Date.now() - GITL_NET.capturedAt : -1
   };
 }
@@ -859,7 +1306,7 @@ const Timeline = {
    ═══════════════════════════════════════════════════════════════ */
 const Reporter = {
   last: null,         // most recent assembled report {kind, detail, text, at}
-  _seen: new Set(),   // dedupe identical auto-captures within a session
+  _seen: new Map(),   // dedupe: signature -> last capture ts (10-min window)
 
   build(kind, detail) {
     const L = (typeof GHOST !== 'undefined') ? GHOST.loop : {};
@@ -884,7 +1331,12 @@ const Reporter = {
     lines.push(`| Send path | ${DIAG?.sendPath || 'n/a'} |`);
     lines.push(`| Health | ${h.badge || ''} ${h.score ?? '?'}/100 (in:${h.input} send:${h.send} stop:${h.stop} msgs:${h.assistantCount}) |`);
     lines.push(`| Net intercept | ${h.netActive ? 'active' : 'off'} |`);
+    try {
+      const lm = (typeof SelectorMemory !== 'undefined') ? SelectorMemory._load()[location.hostname] : null;
+      lines.push(`| Learned selectors | ${lm ? Object.entries(lm).map(([k,v]) => k + ': ' + v.sel).join(' · ') : 'none'} |`);
+    } catch(_) {}
     lines.push(`| Focus | hasFocus:${typeof document!=='undefined'?document.hasFocus():'?'} hidden:${typeof document!=='undefined'?document.hidden:'?'} |`);
+    lines.push(`| Unattended | ${unattendedOn()?'ON':'off'} · ticker:${Ticker.mode} |`);
     lines.push(`| UA | ${typeof navigator!=='undefined'?navigator.userAgent:'?'} |`);
     lines.push(`| When | ${new Date().toISOString()} |`);
     lines.push(``);
@@ -897,6 +1349,12 @@ const Reporter = {
 
   // Auto-capture: assemble + store + surface a non-intrusive affordance.
   capture(kind, detail) {
+    // Dedupe: the same failure re-captured within 10 min just refreshes
+    // the timestamp instead of rebuilding + re-sending a duplicate.
+    const sig = kind + '|' + String(detail || '').slice(0, 120);
+    const seenAt = this._seen.get(sig) || 0;
+    this._seen.set(sig, Date.now());
+    if (this.last && Date.now() - seenAt < 600000) return this.last;
     const text = this.build(kind, detail);
     this.last = { kind, detail, text, at: Date.now() };
     if (typeof GHOST !== 'undefined') GHOST.report = this.last;
@@ -1190,21 +1648,21 @@ const RESUME_TEXT = `Continue.\n\n[Ghost reminder: end each response with ██
    clauses differ ONLY in how/when expansion is permitted. */
 const POSTURES = {
   standard: {
-    label: 'Standard',
-    short: 'Locked plan',
+    label: 'Locked',
+    short: 'Exact plan',
     desc: 'Locked to the plan it declares. No added steps. Most predictable.',
     clause: `\n\n[Posture: STANDARD — locked plan]\nComplete exactly the steps you declared. Do not add, remove, merge, or reorder steps. If you discover the plan is wrong, finish what you can and report it at the end rather than expanding. Keep your declared Y fixed for the whole run.`
   },
   evolving: {
-    label: 'Evolving',
-    short: 'Adaptive mid-run',
-    desc: 'May add steps DURING the run — but only when a real blocker or gap forces it. (Field term: "adaptive".)',
+    label: 'Adaptive',
+    short: 'Grows mid-run',
+    desc: 'The plan may GROW while working — the AI adds steps when a real blocker or gap forces it, justifying each one. (Formerly "Evolving".)',
     clause: `\n\n[Posture: EVOLVING — adaptive mid-run replanning]\nExecute your declared steps one at a time. You MAY add a step during the run ONLY IF a concrete blocker, a missing prerequisite, or a material gap is visible from the work already done and continuing without it would likely fail the original goal.\nBefore adding a step, print on their own lines:\n  Why needed: <one sentence>\n  Why existing steps are insufficient: <one sentence>\nIf that justification is weak, do NOT add the step. Prefer tightening or replacing a future step over adding to the total. Any added step must stay strictly within the ORIGINAL goal — do not expand scope into adjacent topics. Update Y when you legitimately add a step, and keep printing ████░░░░ [Step X of Y].`
   },
   extended: {
-    label: 'Extended',
-    short: 'End-of-run gap check',
-    desc: 'Runs the plan locked, THEN does one gap-check at the end and fills only genuinely valuable holes. (Field term: "review".)',
+    label: 'Audit',
+    short: 'Plan + final gap check',
+    desc: 'Runs the plan locked, THEN performs one end-of-run audit and fills only material gaps. (Formerly "Extended".)',
     clause: `\n\n[Posture: EXTENDED — bounded end-of-run review]\nExecute your declared steps exactly, with no mid-run additions. AFTER the last declared step, perform ONE coverage check against the original goal, its constraints, and the promised deliverable. List only material gaps, errors, or unanswered sub-questions — for each: the gap, why it matters, and the smallest step that closes it. Then complete only those high-value follow-ups. If no material gaps remain, print "No material gaps found" and HALT. Do not invent "nice to have" extras.`
   }
 };
@@ -1240,7 +1698,8 @@ function parseRoadmap(fullText) {
 function sendRoadmapStep() {
   const R = GHOST.roadmap, i = R.index, n = R.steps.length;
   GHOST.loop.detail = `🗺 Step ${i+1}/${n}`;
-  engineSend(`Continue.\n\n[Ghost roadmap — step ${i+1} of ${n}]\n${R.steps[i]}\n\nComplete this step fully and concretely. Deliverable output only, no fluff. End with [[GITL::PROCEED]] when this step is done — or [[GITL::HALT]] only if the ENTIRE roadmap is genuinely finished.`, false)
+  const personaClause = GHOST.persona.perTask && resolvePersonaInject() ? `\n\n[Active committee — maintain all assigned perspectives for this step]\n${resolvePersonaInject()}` : '';
+  engineSend(`Continue.\n\n[Ghost roadmap — step ${i+1} of ${n}]\n${R.steps[i]}\n\nComplete this step fully and concretely. Deliverable output only, no fluff. End with [[GITL::PROCEED]] when this step is done — or [[GITL::HALT]] only if the ENTIRE roadmap is genuinely finished.${personaClause}`, false)
     .then(ok => { if (ok) { R.index = i + 1; _save('rmIndex', R.index); render(); } });
 }
 
@@ -1309,14 +1768,52 @@ async function engineSend(text, skipDelay) {
       pauseWithProbe('Text injection failed — recovery exhausted'); return false;
     }
     await sleep(500);
-    // 5-path send: button → retry → retry → retry → Enter key
+    // Three-stage send with verification (from MCP-SuperAssistant research):
+    // Stage 1: button.click() → verify input cleared
+    // Stage 2: Enter key with composed:true (crosses Shadow DOM)
+    // Stage 3: insertParagraph beforeinput (ProseMirror/Lexical native)
     let sent = false;
-    for (let attempt = 0; attempt < 4; attempt++) {
+    const inputIsEmpty = () => { const v = input.value || input.textContent || ''; return v.trim().length < 4; };
+    // Tier memory: if the button tier failed here last time, don't burn 3 tries on it again.
+    const _lastTier = GM_getValue('sendTier:' + location.hostname, '');
+    const _btnWorked = /^btn-\d+$/.test(_lastTier); // pure button path = the button actually worked last time
+    const _btnTries = (!_lastTier || _btnWorked) ? 3 : 1;
+    for (let attempt = 0; attempt < _btnTries; attempt++) {
       const btn = Adapter.getSendBtn();
-      if (btn && !btn.disabled) { btn.click(); DIAG.sendPath = `btn-${attempt+1}`; sent = true; break; }
-      await sleep(600);
+      if (btn && !btn.disabled) {
+        btn.click(); DIAG.sendPath = `btn-${attempt+1}`;
+        await sleep(400);
+        if (inputIsEmpty()) { sent = true; break; }
+      }
+      await sleep(500);
     }
-    if (!sent) { Adapter.pressEnter(input); DIAG.sendPath = 'enter-key'; }
+    if (!sent) {
+      input.focus();
+      ['keydown','keypress','keyup'].forEach(t => {
+        input.dispatchEvent(new KeyboardEvent(t, { key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true, composed:true }));
+      });
+      DIAG.sendPath = (DIAG.sendPath||'none') + '+enter';
+      await sleep(300);
+      if (inputIsEmpty()) sent = true;
+    }
+    if (!sent) {
+      try { input.dispatchEvent(new InputEvent('beforeinput', { inputType:'insertParagraph', bubbles:true, cancelable:true, composed:true })); } catch(_){}
+      DIAG.sendPath = (DIAG.sendPath||'none') + '+paragraph';
+      await sleep(300);
+      if (inputIsEmpty()) sent = true;
+    }
+    // Tier 5: native form submission — buttonless, survives any button redesign.
+    if (!sent) {
+      try {
+        const f = input.closest && input.closest('form');
+        if (f && f.requestSubmit) {
+          f.requestSubmit();
+          DIAG.sendPath = (DIAG.sendPath||'none') + '+form';
+          await sleep(300);
+          if (inputIsEmpty()) sent = true;
+        }
+      } catch(_){}
+    }
     _onSendOk(text, DIAG.sendPath);
     return true;
   } catch(e) {
@@ -1334,6 +1831,8 @@ async function engineSend(text, skipDelay) {
    the confirmation branch in engineTick. */
 function _onSendOk(text, path) {
   const L = GHOST.loop;
+  GITL_NET.expectUntil = Date.now() + 120000; // heuristic net pulses count for 2 min
+  try { GM_setValue('sendTier:' + location.hostname, String(path || '')); } catch(_) {}
   L.round++;
   L.lastActivity = Date.now();
   L.staleTicks = 0;
@@ -1386,7 +1885,7 @@ async function _refireSend() {
 function engineHalt(reason) {
   const L = GHOST.loop;
   L.state = 'COMPLETE'; L.detail = reason; L.needsPayload = true;
-  clearInterval(L.timer); L.timer = null;
+  Ticker.stop(); L.timer = null;
   Timeline.record('halt', { reason, round: L.round });
   render();
   if (GHOST.ui.soundOn) playBeep();
@@ -1396,7 +1895,7 @@ function engineHalt(reason) {
 function enginePause(reason) {
   const L = GHOST.loop;
   L.state = 'PAUSED'; L.detail = reason;
-  clearInterval(L.timer); L.timer = null;
+  Ticker.stop(); L.timer = null;
   Timeline.record('pause', { reason, round: L.round });
   render();
   notify('⏸ ' + reason);
@@ -1410,7 +1909,7 @@ function engineLimit() {
   L.state = 'LIMIT';
   L.detail = `Hit ${L.maxRounds} auto-continues — chat's still going. ▶ to run ${L.limitStep} more.`;
   L.sendPending = false;
-  clearInterval(L.timer); L.timer = null;
+  Ticker.stop(); L.timer = null;
   Timeline.record('limit', { round: L.round, cap: L.maxRounds });
   render();
   if (GHOST.ui.soundOn) playBeep();
@@ -1424,7 +1923,7 @@ function extendLimit() {
   L.maxRounds += (L.limitStep || 20);
   L.state = 'RUNNING'; L.detail = ''; L.lastActivity = Date.now();
   Timeline.record('limit_extended', { newCap: L.maxRounds, round: L.round });
-  L.timer = setInterval(engineTick, 2500);
+  L.timer = Ticker.start(engineTick, 2500);
   render();
   engineTick();
 }
@@ -1445,7 +1944,7 @@ Then continue the task. End with ████ [Step X of Y] and [[GITL::PROCEED]
   L.maxRounds += (L.limitStep || 20);
   L.state = 'RUNNING'; L.detail = '⊕ Regrounding to original task…'; L.lastActivity = Date.now();
   Timeline.record('reground', { round: L.round, hadTask: !!task });
-  L.timer = setInterval(engineTick, 2500);
+  L.timer = Ticker.start(engineTick, 2500);
   render();
   engineSend(cmd, true);
 }
@@ -1464,7 +1963,7 @@ function engineTick() {
       L.lastActivity = Date.now();
       // fall through: if generating, the branch below will hold the loop
     } else if (Date.now() >= L.sendDeadline) {
-      if (L.sendRetries < SEND_MAX_RETRIES && document.hasFocus() && !document.hidden) {
+      if (L.sendRetries < SEND_MAX_RETRIES && (unattendedOn() || (document.hasFocus() && !document.hidden))) {
         _refireSend();           // re-fire; confirm on a later tick
         return;
       }
@@ -1486,7 +1985,8 @@ function engineTick() {
   // Round limit — soft checkpoint, not a hard stop. The cap exists to
   // catch runaway loops, so we PAUSE and ASK rather than strand the user
   // mid-task (e.g. a chat that legitimately runs to 24 with cap=20).
-  if (L.round >= L.maxRounds) { engineLimit(); return; }
+  // Skipped entirely if drift guard is toggled off.
+  if (GHOST.loop.driftEnabled && L.round >= L.maxRounds) { engineLimit(); return; }
 
   // Still generating
   if (Adapter.isGenerating()) { L.lastActivity = Date.now(); return; }
@@ -1508,6 +2008,7 @@ function engineTick() {
 
   if (result.signal === 'halt') {
     L.staleTicks = 0;
+    L.noSigilStreak = 0; L._nudgedTail = '';
     // Workflow auto-advance
     if (GHOST.workflow.active && GHOST.workflow.autoAdvance) {
       const wf = allWorkflows()[GHOST.workflow.selected] || WORKFLOW_LIBRARY.none;
@@ -1524,31 +2025,100 @@ function engineTick() {
       GHOST.workflow.active = false;
       GHOST.workflow.stageIndex = 0; _save('wfStage', 0);
     }
-    if (L.payloadMode === 'roadmap' && GHOST.roadmap.captured) { engineHalt('✅ Roadmap complete'); resetRoadmap(); return; }
+    if (L.payloadMode === 'roadmap' && GHOST.roadmap.captured) {
+      // Final committee review on roadmap completion
+      if (GHOST.persona.finalReview && !GHOST.persona._reviewDone && GHOST.persona.selected.filter(s=>s&&s!=='none').length>1) {
+        GHOST.persona._reviewDone = true; L.detail = '📋 Committee final review…';
+        const names = GHOST.persona.selected.filter(s=>s&&s!=='none').map(s=>(allPersonas()[s]||{}).label||s).join(', ');
+        engineSend(`[Ghost — Final Committee Review]\nAll work is complete. As a committee of ${names}, conduct a final review:\n1. Each perspective: state your assessment — what is strong, what is missing, what risks remain.\n2. Surface disagreements between perspectives.\n3. Synthesize a final verdict with actionable improvements.\nEnd with [[GITL::HALT]] when the review is complete.`, false);
+        render(); return;
+      }
+      engineHalt('✅ Roadmap complete'); resetRoadmap(); return;
+    }
+    // Final committee review on task completion
+    if (GHOST.persona.finalReview && !GHOST.persona._reviewDone && GHOST.persona.selected.filter(s=>s&&s!=='none').length>1) {
+      GHOST.persona._reviewDone = true; L.detail = '📋 Committee final review…';
+      const names = GHOST.persona.selected.filter(s=>s&&s!=='none').map(s=>(allPersonas()[s]||{}).label||s).join(', ');
+      engineSend(`[Ghost — Final Committee Review]\nThe task is complete. As a committee of ${names}, conduct a final review:\n1. Each perspective: state your assessment — what is strong, what is missing, what risks remain.\n2. Surface disagreements between perspectives.\n3. Synthesize a final verdict with actionable improvements.\nEnd with [[GITL::HALT]] when the review is complete.`, false);
+      render(); return;
+    }
     engineHalt('✅ Task complete');
     return;
   }
 
   if (result.signal === 'proceed') {
     L.staleTicks = 0;
+    L.noSigilStreak = 0; L._nudgedTail = '';
     if (L.payloadMode === 'roadmap') {
       const R = GHOST.roadmap;
       if (!R.captured) {
         if (parseRoadmap(text)) { L.detail = `🗺 Roadmap captured: ${R.steps.length} steps`; render(); sendRoadmapStep(); }
-        else { enginePause('Roadmap mode: no [[GITL::ROADMAP]] list found — review output, then ▶ to retry'); }
+        else if (!R._reask) {
+          // Model planned (it signaled PROCEED) but skipped the machine-readable block —
+          // common with custom GPTs that self-track "[Step X of Y]". Ask once for just the block.
+          R._reask = true;
+          L.detail = '🗺 No roadmap block — re-requesting format (1 auto-retry)…';
+          Timeline.record('roadmap_reask', { round: L.round });
+          engineSend('No [[GITL::ROADMAP]] block was detected in your last response. Do NOT redo the research or execute anything. Output ONLY the roadmap now, in exactly this format:\n\n[[GITL::ROADMAP]]\n1. first concrete step\n2. second concrete step\n3. ...\n\n(3–12 steps, each self-contained) End with [[GITL::PROCEED]]', false);
+          render();
+        }
+        else { enginePause('Roadmap mode: no [[GITL::ROADMAP]] list found after auto-retry — review output, then ▶ to retry'); }
         return;
       }
       if (R.index < R.steps.length) { sendRoadmapStep(); return; }
       if (!R.synthSent) { sendRoadmapSynthesis(); return; }
       engineHalt('✅ Roadmap complete'); resetRoadmap(); return;
     }
-    engineSend('Continue', false);
+    if (GHOST.persona.perTask && resolvePersonaInject()) {
+      engineSend(`Continue.\n\n[Active committee — maintain all assigned perspectives for this step]\n${resolvePersonaInject()}`, false);
+    } else if (hasPendingDirectives()) {
+      // Personas were selected mid-run (or the run began from a paused state) —
+      // deliver the context block once instead of a bare "Continue".
+      GHOST.persona._delivered = true;
+      engineSend('Continue.' + runDirectives(false), false);
+    } else {
+      engineSend('Continue', false);
+    }
     return;
   }
 
-  // No signal
+  // No signal — but only count it as stale if the model is genuinely idle.
+  // Long "Thinking" phases (Perplexity Deep Research, o-series reasoning) produce
+  // no DOM growth and no stop button for minutes at a time; the network channel
+  // is the only honest witness that work is still happening.
+  if (Adapter.isGenerating()) {
+    L.staleTicks = 0;
+    if (!L._thinkNoted) { L._thinkNoted = true; DIAG.push('Still generating (net/stop) — stale counter held'); }
+    L.detail = '🧠 Model is still working…';
+    render();
+    return;
+  }
+  L._thinkNoted = false;
   L.staleTicks++;
-  if (L.staleTicks >= 5) enginePause('No signal detected — review output');
+  const staleLimit = (PLAT && PLAT.staleTicks) || 5;
+  if (L.staleTicks >= staleLimit) {
+    /* v8.1 sigil-free completion fallback: some models (DeepSeek especially)
+       answer fully but never echo the [[GITL::…]] protocol markers. The reply
+       IS complete — generation ended and the text went quiet — so instead of
+       stranding the run, auto-continue once with a protocol reminder. Only
+       after two consecutive sigil-free replies do we pause for review. Every
+       nudge still consumes a round, so drift guard / round limit keep their
+       grip on runaway loops. */
+    const tail = text.slice(-200);
+    if (tail === L._nudgedTail && (L.isSending || L.sendPending)) return; // nudge already in flight
+    if (!L.isSending && !L.sendPending && text.length > 20 && (L.noSigilStreak || 0) < 2 && tail !== L._nudgedTail) {
+      L.noSigilStreak = (L.noSigilStreak || 0) + 1;
+      L._nudgedTail = tail;
+      L.staleTicks = 0;
+      L.detail = `🕯 Reply had no sigil — auto-continuing (${L.noSigilStreak}/2) + re-stating protocol`;
+      DIAG.push(`Sigil missing — soft proceed (${L.noSigilStreak}/2)`);
+      Timeline.record('soft_proceed', { streak: L.noSigilStreak, round: L.round });
+      engineSend('Continue.\n\n[Ghost protocol reminder — your last reply was missing the control marker. From now on END EVERY reply with exactly one of:\n[[GITL::PROCEED]] — more work remains\n[[GITL::HALT]] — the whole task is fully complete\nAlso include "[Step X of Y]" on its own line so progress can be tracked.]', false);
+      render();
+      return;
+    }
+    enginePause('No sigil after 2 auto-continues — review output (the model may be ignoring the protocol)');
+  }
 }
 
 // Watchdog heartbeat (supplements tick)
@@ -1612,7 +2182,7 @@ function startLoop() {
     L.state = 'RUNNING'; L.lastActivity = Date.now(); L.detail = '';
     L.sendPending = false;
     GHOST.workflow.active = GHOST.workflow.selected !== 'none';
-    L.timer = setInterval(engineTick, 2500);
+    L.timer = Ticker.start(engineTick, 2500);
     render(); engineTick();
     return;
   }
@@ -1624,12 +2194,10 @@ function startLoop() {
     L.state = 'RUNNING'; L.lastActivity = Date.now();
     GHOST.workflow.active = GHOST.workflow.selected !== 'none';
     if (L.payloadMode === 'roadmap') { resetRoadmap(); GHOST.workflow.active = false; }
-    const personaInject = resolvePersonaInject();
-    const posture = POSTURES[L.posture] || POSTURES.standard;
-    const postureClause = posture.clause + (L.posture === 'standard' ? '' : POSTURE_CEILING);
-    const full = typed + (personaInject ? `\n\n[Active persona]\n${personaInject}` : '') + PAYLOADS[L.payloadMode].inject + postureClause;
+    const full = typed + runDirectives(true);
+    GHOST.persona._delivered = true;
     engineSend(full, true);
-    L.timer = setInterval(engineTick, 2500);
+    L.timer = Ticker.start(engineTick, 2500);
     render();
     return;
   }
@@ -1639,8 +2207,10 @@ function startLoop() {
     L.needsPayload = false; L.round = 0; L.lastProgress = null; L.staleTicks = 0;
     L.state = 'RUNNING'; L.lastActivity = Date.now(); L.detail = 'Resuming…';
     GHOST.workflow.active = GHOST.workflow.selected !== 'none';
-    engineSend(RESUME_TEXT, true);
-    L.timer = setInterval(engineTick, 2500);
+    // Resume carries persona + posture (+ strategy, unless roadmap owns its own flow).
+    GHOST.persona._delivered = true;
+    engineSend(RESUME_TEXT + runDirectives(L.payloadMode !== 'roadmap'), true);
+    L.timer = Ticker.start(engineTick, 2500);
     render();
     return;
   }
@@ -1661,7 +2231,7 @@ function startQueue(rawLines) {
   L.state = 'RUNNING'; L.lastActivity = Date.now();
   GHOST.workflow.active = false;
   if (GHOST.ui.firstRun) { GHOST.ui.firstRun = false; _save('firstRun', false); }
-  L.timer = setInterval(engineTick, 2500);
+  L.timer = Ticker.start(engineTick, 2500);
   sendRoadmapStep();
   render();
 }
@@ -1681,7 +2251,9 @@ function primaryAction() {
   L.originalTask = '';
   L.lastSignal = 'none'; L.lastConfidence = 0; L.needsPayload = true; L.detail = '';
   L.sendPending = false; L.sendRetries = 0;
-  clearInterval(L.timer); L.timer = null;
+  GHOST.persona._reviewDone = false;
+  GHOST.persona._delivered = false;
+  Ticker.stop(); L.timer = null;
   resetRoadmap();
   render();
 }
@@ -1699,21 +2271,87 @@ window.addEventListener('popstate', () => window.dispatchEvent(new Event('gitl:r
 window.addEventListener('gitl:route', () => {
   if (location.href !== _lastHref) {
     _lastHref = location.href;
-    _cache.clear();
+    _clearElementCaches();
     if (GHOST.loop.state === 'RUNNING') enginePause('Route changed — paused');
   }
 });
 
-/* Manual re-detect (v7.1): force a clean re-resolution of the page's
-   chat input / send button. Fixes the case where you move browser → app →
-   back into the same chat: the URL is unchanged so the route-watcher never
-   fired, but the SPA rebuilt the DOM and Ghost is holding stale/detached
-   element references (or the shadow-walk throttle is blocking a re-scan).
-   This clears every cache, re-resolves the platform, and re-probes —
-   no page reload, no hopping between chats. */
-function reDetect() {
+/* One place that forgets every cached element reference — the route watcher,
+   reDetect, and the visibility healer all funnel through here so no cache
+   (selector, shadow-walk throttle, heuristic) can be missed again. */
+function _clearElementCaches() {
   _cache.clear();
   _deepLast.clear();
+  _heurCache.input = { el: null, ts: 0 };
+  _heurCache.send  = { el: null, ts: 0 };
+}
+
+/* Silent self-heal (v8.1): coming back from another app/tab is exactly when
+   the SPA has rebuilt its DOM underneath us. If our cached composer is now a
+   detached node, drop the caches so the next lookup re-resolves — no UI
+   noise, no user action needed. This removes most manual 🔄 presses. */
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') return;
+  const c = _cache.get('in');
+  if (c && !c.isConnected) _clearElementCaches();
+});
+
+/* Manual re-detect (v7.1, hardened v8.1): force a clean re-resolution of the
+   page's chat input / send button. Fixes the case where you move browser →
+   app → back into the same chat: the URL is unchanged so the route-watcher
+   never fired, but the SPA rebuilt the DOM and Ghost is holding stale nodes.
+   v8.1: no longer one-shot. If the first pass misses (SPA mid-remount — the
+   exact moment users press 🔄), a MutationObserver + interval keeps watching
+   for up to 12s and reports success the moment the composer appears. */
+const _redetectWatch = { obs: null, timer: null, deadline: 0, nudged: false };
+
+function _redetectStop() {
+  try { _redetectWatch.obs?.disconnect(); } catch(_){}
+  if (_redetectWatch.timer) clearInterval(_redetectWatch.timer);
+  _redetectWatch.obs = null; _redetectWatch.timer = null; _redetectWatch.deadline = 0;
+  try { document.querySelector('#g-redetect')?.classList.remove('spin'); } catch(_){}
+}
+
+function _redetectCheck() {
+  const input = Adapter.getInput();
+  if (input) {
+    _redetectStop();
+    try { DIAG.runProbe(); } catch(_){}
+    Timeline.record('redetect_late', { platform: PLAT?.label });
+    GHOST.loop.detail = `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`;
+    render();
+    return true;
+  }
+  if (Date.now() > _redetectWatch.deadline) {
+    _redetectStop();
+    Timeline.record('redetect_timeout', { platform: PLAT?.label });
+    GHOST.loop.detail = '🔄 Still no chat input after 12s. Tap inside the chat box once, then 🔄 again.';
+    render();
+    return false;
+  }
+  // Focus nudge (once): some editors only mount their real composer on focus.
+  // Never steal focus from the user — only when nothing meaningful is focused.
+  if (!_redetectWatch.nudged && Date.now() > _redetectWatch.deadline - 9000) {
+    _redetectWatch.nudged = true;
+    try {
+      const ae = document.activeElement;
+      if (!ae || ae === document.body) {
+        for (const el of _qAll(['textarea:not([disabled])','div[contenteditable="true"]'])) {
+          if (_visible(el)) { el.focus(); break; }
+        }
+      }
+    } catch(_){}
+  }
+  return false;
+}
+
+function reDetect() {
+  _redetectStop();
+  _clearElementCaches();
+  // Abandoned streams from a background hop can leave stale counters that
+  // fake "still generating" — zero the network expectation state too.
+  GITL_NET._open = 0;
+  GITL_NET.expectUntil = 0;
   // Re-resolve platform in case the host changed (e.g. app vs web shell).
   let matched = null;
   for (const [, p] of Object.entries(PROFILES)) { if (p.host.test(location.hostname)) { matched = p; break; } }
@@ -1723,12 +2361,27 @@ function reDetect() {
   const send  = Adapter.getSendBtn();
   try { DIAG.runProbe(); } catch(_){}
   Timeline.record('redetect', { found_input: !!input, found_send: !!send, platform: PLAT?.label });
-  const ok = !!input;
-  GHOST.loop.detail = ok
-    ? `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`
-    : '🔄 Re-detected — still no chat input. Try clicking inside the chat box once, then re-detect.';
+  if (input) {
+    GHOST.loop.detail = `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`;
+    render();
+    return true;
+  }
+  // Not found yet — keep watching. SPAs often remount the composer a beat
+  // after the user notices it's "gone" and presses 🔄.
+  GHOST.loop.detail = '🔄 Searching for the chat box…';
   render();
-  return ok;
+  try { document.querySelector('#g-redetect')?.classList.add('spin'); } catch(_){}
+  _redetectWatch.deadline = Date.now() + 12000;
+  _redetectWatch.nudged = false;
+  try {
+    _redetectWatch.obs = new MutationObserver(() => {
+      if (_redetectWatch._raf) return; // throttle bursts to one check per frame-ish
+      _redetectWatch._raf = setTimeout(() => { _redetectWatch._raf = null; _redetectCheck(); }, 250);
+    });
+    _redetectWatch.obs.observe(document.body, { childList: true, subtree: true });
+  } catch(_){}
+  _redetectWatch.timer = setInterval(_redetectCheck, 800);
+  return false;
 }
 
 /* ═══════════════════════════════════════════════════════════════
@@ -2129,7 +2782,7 @@ function applyFilter(msgs) {
   return msgs;
 }
 
-const GM_KEYS = ['projectName','projectSlug','wfSelected','wfStage','wfAuto','wfPause','persona','payloadMode','posture','maxRounds','customProceed','customStop','sigWindow','expFormat','expFilter','expRoles','expThinking','expSlug','panelCollapsed','panelPosition','soundOn','notifyOn','cfgAdv','expAdv','firstRun','customSites','rmSteps','rmIndex','rmCaptured','qDraft','customPersonas','customWorkflows'];
+const GM_KEYS = ['projectName','projectSlug','wfSelected','wfStage','wfAuto','wfPause','persona','personaCommittee','personaPerTask','personaFinalReview','payloadMode','posture','maxRounds','driftEnabled','customProceed','customStop','sigWindow','expFormat','expFilter','expRoles','expThinking','expSlug','panelCollapsed','panelPosition','soundOn','notifyOn','cfgAdv','expAdv','skinTheme','customSkin','accentHue','unattended','firstRun','customSites','rmSteps','rmIndex','rmCaptured','qDraft','customPersonas','customWorkflows'];
 
 function downloadText(content, filename, mime) {
   const blob = new Blob([content], { type: mime });
@@ -2184,7 +2837,7 @@ function workshopImport() {
   inp.click();
 }
 
-function exportRescue() {
+function exportBackupHandoff() {
   const all = extractMessages();
   const mission = (all.find(m => m.role === 'user')?.text || '').slice(0, 600);
   const msgs = all.slice(-10); // verbatim tail, both roles — the part a stuck chat can't summarize for you
@@ -2193,7 +2846,7 @@ function exportRescue() {
   const steps = R.steps.length ? R.steps.map((s,i) =>
     `${i < R.index ? '✓' : i === R.index ? '▶' : '·'} ${i+1}. ${s}`).join('\n') : '(none)';
   const md = [
-    '# 🛟 GITL Rescue File',
+    '# 🧷 GITL Backup Handoff',
     '*Use this when a chat is stuck, full, or dead and cannot be prompted anymore. Paste it into a NEW chat to continue the work. (If the chat still responds, the 🤝 Handoff button produces a better briefing — the AI writes it itself.)*',
     '',
     '```yaml',
@@ -2201,7 +2854,7 @@ function exportRescue() {
     `platform: ${PLAT.label}`,
     `exported: ${new Date().toISOString()}`,
     `mode: ${GHOST.loop.payloadMode}`,
-    `persona: ${(PERSONA_LIBRARY[GHOST.persona.selected]||PERSONA_LIBRARY.none).label}`,
+    `persona: ${(GHOST.persona.selected||['none']).filter(s=>s&&s!=='none').map(s=>(allPersonas()[s]||{}).label||s).join(', ')||'None'}`,
     `workflow: ${wf} (stage ${W.stageIndex})`,
     `rounds: ${GHOST.loop.round}`,
     `last_signal: ${GHOST.loop.lastSignal}`,
@@ -2223,9 +2876,9 @@ function exportRescue() {
     '## Last 10 messages — verbatim (most recent last)',
     ...msgs.map((m) => `### ${m.role === 'user' ? '👤 User' : '🤖 Assistant'}\n${m.text}\n`),
     '---',
-    `*Rescue file generated by Ghost in the Loop v${VER}*`
+    `*Backup Handoff — generated by Ghost in the Loop v${VER}. The lightweight sibling of Handoff: state + last 10 messages only, enough to resume elsewhere.*`
   ].join('\n');
-  downloadText(md, buildFilename('rescue').replace(/\.\w+$/,'') + '.md', 'text/markdown');
+  downloadText(md, buildFilename('backup-handoff').replace(/\.\w+$/,'') + '.md', 'text/markdown');
 }
 
 const HANDOFF_IN_CHAT = `Stop all other work. Produce a COMPLETE HANDOFF REPORT for this entire conversation, in ONE markdown code block, structured exactly as:
@@ -2303,7 +2956,7 @@ async function runExport() {
   const ts = new Date().toLocaleString();
   let content, mime;
   if (GHOST.export.format === 'json') {
-    content = JSON.stringify({ project: proj, platform: PLAT.label, exported: ts, rounds: GHOST.loop.round, workflow: (allWorkflows()[GHOST.workflow.selected]||WORKFLOW_LIBRARY.none).label, persona: (allPersonas()[GHOST.persona.selected]||PERSONA_LIBRARY.none).label, messages: msgs }, null, 2);
+    content = JSON.stringify({ project: proj, platform: PLAT.label, exported: ts, rounds: GHOST.loop.round, workflow: (allWorkflows()[GHOST.workflow.selected]||WORKFLOW_LIBRARY.none).label, persona: (GHOST.persona.selected||['none']).filter(s=>s&&s!=='none').map(s=>(allPersonas()[s]||{}).label||s).join(', ')||'None', messages: msgs }, null, 2);
     mime = 'application/json';
   } else {
     const lines = [`# Ghost Export — ${proj}`, `**Platform:** ${PLAT.label} | **Exported:** ${ts} | **Rounds:** ${GHOST.loop.round}`, '', '---', ''];
@@ -2410,6 +3063,220 @@ function playBeep() {
   } catch(_){}
 }
 
+/* ══════════════════════════════════════════════════════════════
+   SKIN — token-based theme engine (d6)
+   Skins are DATA, not code: a whitelist of CSS custom properties
+   (+ enumerated fx flags) applied to the panel root. A skin cannot
+   add, remove, or restructure controls — structure and behavior are
+   owned by core. Unknown tokens from newer/older versions are
+   silently ignored, so community skins stay forward-compatible.
+   ══════════════════════════════════════════════════════════════ */
+const SKIN_TOKENS = {
+  '--g-bg':'#111214','--g-bg-deep':'#0c0d10','--g-surface':'#18191c',
+  '--g-surface-2':'#16171b','--g-surface-3':'#1c1d22','--g-hover':'#222329',
+  '--g-border':'#27282e','--g-border-2':'#2e2f35','--g-text':'#c9cad0',
+  '--g-text-mid':'#888','--g-text-dim':'#555','--g-text-hot':'#fff',
+  '--g-text-low':'#666','--g-text-faint':'#444','--g-text-ghost':'#333','--g-muted':'#6b7280',
+  '--g-accent':'#818cf8','--g-accent-text':'#a5b4fc','--g-accent-deep':'#3730a3',
+  '--g-accent-bg':'#1a1b2e','--g-ok':'#34d399','--g-ok-deep':'#064e3b',
+  '--g-ok-bg':'#052e1c','--g-warn':'#fbbf24','--g-err':'#f87171',
+  '--g-radius':'12px','--g-shadow':'0 10px 32px rgba(0,0,0,.65)',
+  '--g-font':"'SF Mono','Cascadia Code','JetBrains Mono','Fira Mono',monospace",
+  '--g-blur':'0px','--g-aur1':'transparent','--g-aur2':'transparent','--g-aur3':'transparent'
+};
+const SKIN_FX = {
+  border:  ['none','aurora','glow'],
+  ghost:   ['none','float','flicker','halo','glow'],
+  tabs:    ['none','underline','pill'],
+  progress:['none','shimmer','ekg'],
+  surface: ['none','sheen']
+};
+const SKIN_PRESETS = {
+  classic:{ name:'Classic', tokens:{}, fx:{} },
+  aurora:{ name:'Aurora', fx:{ border:'aurora', ghost:'float', tabs:'underline', progress:'shimmer', surface:'sheen' }, tokens:{
+    '--g-bg':'#12132b','--g-bg-deep':'#0b0c1f','--g-surface':'#1a1c3a','--g-surface-2':'#16182f',
+    '--g-surface-3':'#1e2040','--g-hover':'#232655','--g-border':'#2b2e5c','--g-border-2':'#3a3d78',
+    '--g-text':'#d6d8f2','--g-muted':'#7d82b8','--g-accent':'#8b9dff','--g-accent-text':'#b9c4ff',
+    '--g-accent-deep':'#4338ca','--g-accent-bg':'#1d1f4a','--g-blur':'8px',
+    '--g-shadow':'0 12px 40px rgba(40,30,120,.55)',
+    '--g-aur1':'#4f7cff','--g-aur2':'#a855f7','--g-aur3':'#ff6ac1' } },
+  glass:{ name:'Glass', fx:{ ghost:'halo', tabs:'underline', surface:'sheen' }, tokens:{
+    '--g-bg':'#171a1f','--g-bg-deep':'#101318','--g-surface':'#1d2127','--g-surface-2':'#191c22',
+    '--g-surface-3':'#20242b','--g-hover':'#242932','--g-border':'#2a2f38','--g-border-2':'#343a45',
+    '--g-text':'#d3d7de','--g-accent':'#7dd3fc','--g-accent-text':'#bae6fd','--g-accent-deep':'#0369a1',
+    '--g-accent-bg':'#16222c','--g-blur':'10px','--g-shadow':'0 10px 36px rgba(0,0,0,.5)' } },
+  metal:{ name:'Metal', fx:{ surface:'sheen', tabs:'pill' }, tokens:{
+    '--g-bg':'#16171a','--g-surface':'#202227','--g-surface-2':'#1b1d21','--g-surface-3':'#24262c',
+    '--g-hover':'#282b32','--g-border':'#33363e','--g-border-2':'#454956','--g-text':'#cfd3da',
+    '--g-accent':'#93a6c4','--g-accent-text':'#c2d0e6','--g-accent-deep':'#3b4d6b',
+    '--g-accent-bg':'#1b2230','--g-shadow':'0 8px 28px rgba(0,0,0,.7)' } },
+  neon:{ name:'Neon', fx:{ border:'glow', ghost:'flicker', tabs:'pill', progress:'ekg' }, tokens:{
+    '--g-bg':'#0a0b0f','--g-bg-deep':'#060709','--g-surface':'#101218','--g-surface-2':'#0d0f14',
+    '--g-surface-3':'#14161d','--g-hover':'#171a26','--g-border':'#1f2230','--g-border-2':'#2b2f45',
+    '--g-text':'#d8dbea','--g-accent':'#22d3ee','--g-accent-text':'#67e8f9','--g-accent-deep':'#0e7490',
+    '--g-accent-bg':'#0b1b22','--g-shadow':'0 0 24px rgba(34,211,238,.25), 0 10px 32px rgba(0,0,0,.7)' } },
+  clay:{ name:'Clay', fx:{ ghost:'float', tabs:'pill' }, tokens:{
+    '--g-bg':'#17161a','--g-surface':'#221f26','--g-surface-2':'#1c1a20','--g-surface-3':'#27242c',
+    '--g-hover':'#2a2731','--g-border':'#322e38','--g-border-2':'#423d4a','--g-text':'#d9d4de',
+    '--g-accent':'#f19a7e','--g-accent-text':'#ffc4ae','--g-accent-deep':'#9a4a35',
+    '--g-accent-bg':'#2a1e1e','--g-radius':'16px','--g-shadow':'0 12px 30px rgba(0,0,0,.55)' } },
+  liquid:{ name:'Liquid', fx:{ border:'aurora', surface:'sheen', ghost:'halo', tabs:'underline', progress:'shimmer' }, tokens:{
+    '--g-bg':'rgba(18,22,30,.55)','--g-bg-deep':'rgba(10,13,20,.6)','--g-surface':'rgba(30,36,48,.55)',
+    '--g-surface-2':'rgba(24,29,40,.5)','--g-surface-3':'rgba(36,43,58,.55)','--g-hover':'rgba(52,62,84,.6)',
+    '--g-border':'rgba(140,170,220,.28)','--g-border-2':'rgba(160,190,240,.4)','--g-text':'#e8edf7',
+    '--g-muted':'#93a0bd','--g-accent':'#8fd0ff','--g-accent-text':'#c9e7ff','--g-accent-deep':'#1e6fae',
+    '--g-accent-bg':'rgba(60,110,170,.22)','--g-blur':'16px','--g-shadow':'0 16px 48px rgba(10,20,40,.55)',
+    '--g-aur1':'#9bd8ff','--g-aur2':'#c3b2ff','--g-aur3':'#8fffe0' } },
+  oled:{ name:'OLED', fx:{ border:'glow', ghost:'glow', progress:'ekg' }, tokens:{
+    '--g-bg':'#000000','--g-bg-deep':'#000000','--g-surface':'#0b0b0e','--g-surface-2':'#08080a',
+    '--g-surface-3':'#101014','--g-hover':'#15151b','--g-border':'#1d1d24','--g-border-2':'#2a2a34',
+    '--g-text':'#e6e6ee','--g-text-mid':'#9a9aa8','--g-muted':'#6a6a78','--g-accent':'#7c8cff',
+    '--g-accent-text':'#aeb8ff','--g-accent-deep':'#2e37b8','--g-accent-bg':'#0e1030',
+    '--g-shadow':'0 0 0 1px #14141a, 0 14px 34px rgba(0,0,0,.9)' } },
+  paper:{ name:'Paper', fx:{ tabs:'underline' }, tokens:{
+    '--g-bg':'#f5f1e8','--g-bg-deep':'#ece7db','--g-surface':'#efe9dc','--g-surface-2':'#f2ede2',
+    '--g-surface-3':'#e9e2d2','--g-hover':'#e3dcc9','--g-border':'#d6cdb8','--g-border-2':'#c4b99f',
+    '--g-text':'#2a261f','--g-text-mid':'#5c564a','--g-text-dim':'#8a8271','--g-text-hot':'#141210',
+    '--g-text-low':'#6e6759','--g-text-faint':'#938b7a','--g-text-ghost':'#a89f8d','--g-muted':'#7a715f',
+    '--g-accent':'#6d4fc4','--g-accent-text':'#4c2f9e','--g-accent-deep':'#6d4fc4','--g-accent-bg':'#e9e1f7',
+    '--g-ok':'#176b41','--g-ok-deep':'#9cc9ae','--g-ok-bg':'#dff0e5','--g-warn':'#946200','--g-err':'#b3442e',
+    '--g-shadow':'0 10px 28px rgba(90,80,60,.35)' } },
+  hud:{ name:'HUD', fx:{ border:'glow', ghost:'flicker', tabs:'underline', progress:'ekg' }, tokens:{
+    '--g-bg':'#050708','--g-bg-deep':'#000000','--g-surface':'#0a0f10','--g-surface-2':'#080c0d',
+    '--g-surface-3':'#0d1415','--g-hover':'#101a1c','--g-border':'#123033','--g-border-2':'#1a464b',
+    '--g-text':'#bdf5f7','--g-text-mid':'#5f9498','--g-muted':'#3f6367','--g-accent':'#22e0e6',
+    '--g-accent-text':'#8ff2f5','--g-accent-deep':'#0e6a6f','--g-accent-bg':'#04191b',
+    '--g-shadow':'0 0 0 1px #123033, 0 10px 30px rgba(0,0,0,.8)' } },
+  nova:{ name:'Nova', fx:{ border:'aurora', ghost:'halo', tabs:'pill', progress:'shimmer', surface:'sheen' }, tokens:{
+    '--g-bg':'#14101f','--g-bg-deep':'#0c0a17','--g-surface':'#1d1830','--g-surface-2':'#181428',
+    '--g-surface-3':'#241d3a','--g-hover':'#2b2245','--g-border':'#2f2650','--g-border-2':'#3d3268',
+    '--g-text':'#e9def0','--g-muted':'#9080ad','--g-accent':'#ec4fa0','--g-accent-text':'#ff9fd0',
+    '--g-accent-deep':'#7a2160','--g-accent-bg':'#2a1330','--g-shadow':'0 14px 42px rgba(70,30,90,.5)',
+    '--g-aur1':'#ec4fa0','--g-aur2':'#8b5cf6','--g-aur3':'#38bdf8' } },
+  ion:{ name:'Ion', fx:{ surface:'sheen', ghost:'halo', tabs:'pill' }, tokens:{
+    '--g-bg':'#18191a','--g-bg-deep':'#101112','--g-surface':'#212324','--g-surface-2':'#1c1e1f',
+    '--g-surface-3':'#26282a','--g-hover':'#2b2e30','--g-border':'#323536','--g-border-2':'#454849',
+    '--g-text':'#d6dadb','--g-muted':'#7a8082','--g-accent':'#2dd4dc','--g-accent-text':'#8fe9ed',
+    '--g-accent-deep':'#116d72','--g-accent-bg':'#132325','--g-radius':'10px',
+    '--g-shadow':'0 8px 26px rgba(0,0,0,.75)' } },
+  flow:{ name:'Flow', fx:{ tabs:'pill' }, tokens:{
+    '--g-bg':'#131722','--g-bg-deep':'#0d1019','--g-surface':'#1a2030','--g-surface-2':'#161b28',
+    '--g-surface-3':'#1e2536','--g-hover':'#232b3f','--g-border':'#28324a','--g-border-2':'#334060',
+    '--g-text':'#d8dfef','--g-muted':'#6d7896','--g-accent':'#38bdf8','--g-accent-text':'#93d9fb',
+    '--g-accent-deep':'#0d6ba8','--g-accent-bg':'#0f2740','--g-blur':'0px',
+    '--g-shadow':'0 6px 20px rgba(0,0,0,.4)' } }
+};
+const SKIN = {
+  LIMIT_BYTES: 8*1024,
+  VAL_MAX: 240,
+  _bad: /url\s*\(|expression\s*\(|@import|javascript:|[<>{};]/i,
+  /* Validate untrusted skin input (string or object). Unknown tokens and
+     unknown fx are DROPPED, never fatal — this is the forward-compat rule. */
+  validate(raw) {
+    let o = raw;
+    if (typeof raw === 'string') {
+      if (raw.length > this.LIMIT_BYTES) return { ok:false, error:'file too large' };
+      try { o = JSON.parse(raw); } catch(_) { return { ok:false, error:'not valid JSON' }; }
+    }
+    if (!o || typeof o !== 'object' || Array.isArray(o) || (o.kind && o.kind !== 'skin'))
+      return { ok:false, error:'not a skin file' };
+    const name = String(o.name || 'Custom').replace(/[<>&"'`]/g,'').slice(0,40) || 'Custom';
+    const tokens = {}; let dropped = 0;
+    const tsrc = (o.tokens && typeof o.tokens === 'object') ? o.tokens : {};
+    for (const [k,v] of Object.entries(tsrc)) {
+      if (!(k in SKIN_TOKENS)) { dropped++; continue; }
+      const val = String(v).trim();
+      if (!val || val.length > this.VAL_MAX || this._bad.test(val)) { dropped++; continue; }
+      tokens[k] = val;
+    }
+    const fx = {}; const fsrc = (o.fx && typeof o.fx === 'object') ? o.fx : {};
+    for (const [k,v] of Object.entries(fsrc)) {
+      if (SKIN_FX[k] && SKIN_FX[k].includes(v)) fx[k] = v; else dropped++;
+    }
+    return { ok:true, skin:{ kind:'skin', gitlSkin:1, name, tokens, fx }, dropped };
+  },
+  _hexToHsl(hex) {
+    let h = hex.replace('#',''); if (h.length === 3) h = h.split('').map(c=>c+c).join('');
+    const r = parseInt(h.slice(0,2),16)/255, g = parseInt(h.slice(2,4),16)/255, b = parseInt(h.slice(4,6),16)/255;
+    const mx = Math.max(r,g,b), mn = Math.min(r,g,b), l = (mx+mn)/2;
+    if (mx === mn) return [0,0,Math.round(l*100)];
+    const d = mx-mn, s = l > .5 ? d/(2-mx-mn) : d/(mx+mn);
+    let hu = mx===r ? (g-b)/d + (g<b?6:0) : mx===g ? (b-r)/d + 2 : (r-g)/d + 4;
+    return [Math.round(hu*60), Math.round(s*100), Math.round(l*100)];
+  },
+  /* Rotate a hex color to hue h, preserving its own saturation/lightness.
+     Non-hex values pass through untouched. */
+  hueShift(val, h) {
+    if (!/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(String(val))) return val;
+    const [,s,l] = this._hexToHsl(val);
+    return `hsl(${((h%360)+360)%360} ${s}% ${l}%)`;
+  },
+  baseHue() {
+    const sk = this.resolve();
+    return this._hexToHsl(sk.tokens['--g-accent'] || SKIN_TOKENS['--g-accent'])[0];
+  },
+  resolve() {
+    const id = GHOST.ui.skinTheme;
+    if (id === 'custom') {
+      const r = this.validate(GHOST.ui.customSkin || '');
+      return r.ok ? r.skin : SKIN_PRESETS.classic;
+    }
+    return SKIN_PRESETS[id] || SKIN_PRESETS.classic;
+  },
+  /* Apply active skin to the panel root. Only sets CSS custom properties
+     and enumerated data-fx-* attributes — never touches structure. */
+  apply() {
+    try {
+      const p = (typeof panel !== 'undefined' && panel) ? panel : document.getElementById('gitl');
+      if (!p) return;
+      const sk = this.resolve();
+      for (const k of Object.keys(SKIN_TOKENS)) {
+        const v = sk.tokens[k];
+        if (v != null) p.style.setProperty(k, v); else p.style.removeProperty(k);
+      }
+      const h = GHOST.ui.accentHue;
+      if (Number.isFinite(h)) {
+        for (const k of ['--g-accent','--g-accent-text','--g-accent-deep','--g-accent-bg'])
+          p.style.setProperty(k, this.hueShift(sk.tokens[k] || SKIN_TOKENS[k], h));
+      }
+      for (const k of Object.keys(SKIN_FX)) {
+        const dk = 'fx' + k[0].toUpperCase() + k.slice(1);
+        const v = sk.fx && sk.fx[k];
+        if (v && v !== 'none') p.dataset[dk] = v; else delete p.dataset[dk];
+      }
+    } catch(e) { DIAG.push('skin apply: ' + e.message); }
+  },
+  importFile() {
+    const inp = document.createElement('input');
+    inp.type = 'file';
+    inp.accept = '.json,.gitl.json,application/json';
+    inp.addEventListener('change', () => {
+      const file = inp.files && inp.files[0];
+      if (!file) return;
+      if (file.size > this.LIMIT_BYTES) { GHOST.loop.detail = `⚠ Skin too large (max ${Math.round(this.LIMIT_BYTES/1024)} KB)`; render(); return; }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const res = this.validate(String(reader.result || ''));
+        if (!res.ok) { GHOST.loop.detail = `⚠ Skin import failed: ${res.error}`; render(); return; }
+        GHOST.ui.customSkin = JSON.stringify(res.skin); _save('customSkin', GHOST.ui.customSkin);
+        GHOST.ui.skinTheme = 'custom'; _save('skinTheme','custom');
+        this.apply();
+        GHOST.loop.detail = `✓ Skin “${res.skin.name}” applied` + (res.dropped ? ` · ${res.dropped} field(s) ignored` : '');
+        render();
+      };
+      reader.onerror = () => { GHOST.loop.detail = '⚠ Could not read skin file'; render(); };
+      reader.readAsText(file);
+    });
+    inp.click();
+  },
+  exportCurrent() {
+    const sk = this.resolve();
+    const out = { kind:'skin', gitlSkin:1, name:sk.name, tokens:sk.tokens, fx:sk.fx||{} };
+    downloadText(JSON.stringify(out, null, 2),
+      `${String(sk.name||'skin').toLowerCase().replace(/\W+/g,'-')}.gitl.json`, 'application/json');
+  }
+};
+
 /* ═══════════════════════════════════════════════════════════════
    UI — STYLES
    Deferred: GM_addStyle / appendChild require document.head, which is
@@ -2419,118 +3286,150 @@ let _stylesInjected = false;
 function injectStyles() {
   if (_stylesInjected) return;
   _stylesInjected = true;
-  const css = `
-#gitl{position:fixed;z-index:2147483647;width:268px;max-width:calc(100vw - 16px);background:#111214;border:1px solid #27282e;
-  border-radius:12px;padding:10px 12px;font:11.5px 'SF Mono','Cascadia Code','JetBrains Mono','Fira Mono',monospace;
-  color:#c9cad0;box-shadow:0 10px 32px rgba(0,0,0,.65);user-select:none;transition:width .2s}
+  const css = `\n#gitl{--g-bg:#111214;--g-bg-deep:#0c0d10;--g-surface:#18191c;--g-surface-2:#16171b;--g-surface-3:#1c1d22;--g-hover:#222329;--g-border:#27282e;--g-border-2:#2e2f35;--g-text:#c9cad0;--g-text-mid:#888;--g-text-dim:#555;--g-muted:#6b7280;--g-accent:#818cf8;--g-accent-text:#a5b4fc;--g-accent-deep:#3730a3;--g-accent-bg:#1a1b2e;--g-ok:#34d399;--g-ok-deep:#064e3b;--g-ok-bg:#052e1c;--g-warn:#fbbf24;--g-err:#f87171;--g-radius:12px;--g-shadow:0 10px 32px rgba(0,0,0,.65);--g-font:'SF Mono','Cascadia Code','JetBrains Mono','Fira Mono',monospace;--g-text-hot:#fff;--g-text-low:#666;--g-text-faint:#444;--g-text-ghost:#333;--g-blur:0px;--g-aur1:transparent;--g-aur2:transparent;--g-aur3:transparent}\n#gitl{backdrop-filter:blur(var(--g-blur));-webkit-backdrop-filter:blur(var(--g-blur))}\n#gitl[data-fx-border="aurora"]::before,#gitl[data-fx-border="glow"]::before{content:"";position:absolute;inset:-1px;border-radius:inherit;padding:1px;-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);-webkit-mask-composite:xor;mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);mask-composite:exclude;pointer-events:none}\n#gitl[data-fx-border="aurora"],#gitl[data-fx-border="glow"]{border-color:transparent}\n#gitl[data-fx-border="aurora"]::before{background:linear-gradient(120deg,var(--g-aur1),var(--g-aur2),var(--g-aur3),var(--g-aur1));background-size:300% 100%;animation:gaur 14s linear infinite;opacity:.6}\n#gitl[data-run="1"][data-fx-border="aurora"]::before{animation-duration:5s;opacity:1}\n#gitl[data-fx-border="glow"]::before{background:linear-gradient(120deg,transparent 35%,var(--g-accent) 50%,transparent 65%);background-size:280% 100%;animation:gbreath 7s ease-in-out infinite;opacity:.5}\n#gitl[data-run="1"][data-fx-border="glow"]::before{animation:gaur 4.5s linear infinite;opacity:.95}\n#gitl .g-ghost{display:inline-block}\n#gitl[data-fx-ghost="float"] .g-ghost{animation:gfloat 3.2s ease-in-out infinite}\n#gitl[data-fx-ghost="flicker"] .g-ghost{animation:gflick 5s linear infinite}\n#gitl[data-run="1"][data-fx-ghost="flicker"] .g-ghost{animation-duration:2.4s}\n#gitl[data-fx-ghost="halo"] .g-ghost{animation:ghalo 4.5s ease-in-out infinite}\n#gitl[data-run="1"][data-fx-ghost="halo"] .g-ghost{animation-duration:2s}\n#gitl[data-fx-ghost="glow"] .g-ghost{filter:drop-shadow(0 0 5px var(--g-accent))}\n#gitl[data-run="1"][data-fx-ghost="glow"] .g-ghost{animation:ghalo 2.2s ease-in-out infinite}\n#gitl[data-fx-tabs="underline"] .g-tab{background:transparent;border-color:transparent;border-radius:0;position:relative}\n#gitl[data-fx-tabs="underline"] .g-tab:hover{background:var(--g-hover)}\n#gitl[data-fx-tabs="underline"] .g-tab.act{background:transparent;border-color:transparent;color:var(--g-accent-text)}\n#gitl[data-fx-tabs="underline"] .g-tab.act::after{content:"";position:absolute;left:14%;right:14%;bottom:-2px;height:2px;border-radius:2px;background:linear-gradient(90deg,transparent,var(--g-accent),transparent)}\n#gitl[data-fx-tabs="pill"] .g-tab{border-radius:999px}\n#gitl[data-fx-progress="shimmer"] .g-fill{background:linear-gradient(90deg,var(--g-accent-deep),var(--g-accent),var(--g-accent-deep));background-size:220% 100%;animation:gaur 3.5s linear infinite}\n#gitl[data-run="1"][data-fx-progress="shimmer"] .g-fill{animation-duration:1.8s}\n#gitl[data-fx-progress="ekg"] .g-trk{position:relative;overflow:hidden}\n#gitl[data-fx-progress="ekg"] .g-trk::after{content:"";position:absolute;top:0;bottom:0;left:0;width:16%;background:linear-gradient(90deg,transparent,var(--g-accent),transparent);opacity:.45;animation:gekg 2.6s ease-in-out infinite}\n#gitl[data-run="1"][data-fx-progress="ekg"] .g-trk::after{opacity:.9;animation-duration:1.2s}\n#gitl[data-fx-surface="sheen"]::after{content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none;background:linear-gradient(115deg,transparent 42%,rgba(255,255,255,.05) 50%,transparent 58%);background-size:280% 100%;animation:gsheen 11s linear infinite;opacity:.7}\n#gitl[data-run="1"][data-fx-surface="sheen"]::after{animation-duration:5s;opacity:1}\n@keyframes gaur{0%{background-position:0% 50%}100%{background-position:300% 50%}}\n@keyframes gbreath{0%,100%{opacity:.3}50%{opacity:.75}}\n@keyframes gflick{0%,88%,92%,100%{opacity:1}90%{opacity:.35}95%{opacity:.7}}\n@keyframes ghalo{0%,100%{filter:drop-shadow(0 0 2px var(--g-accent))}50%{filter:drop-shadow(0 0 8px var(--g-accent))}}\n@keyframes gekg{0%{transform:translateX(-110%)}100%{transform:translateX(740%)}}\n@keyframes gsheen{0%{background-position:130% 0}100%{background-position:-50% 0}}\n#gitl[data-explain="1"] #g-explain-tog{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}\n#gitl[data-explain="1"] .g-body{cursor:help}\n.g-xtip{position:absolute;left:8px;right:8px;top:54px;z-index:9;background:var(--g-surface-3);border:1px solid var(--g-accent-deep);border-radius:7px;padding:6px 22px 7px 8px;font-size:9.5px;line-height:1.45;color:var(--g-text);box-shadow:var(--g-shadow)}\n.g-xtip b{color:var(--g-accent-text)}\n.g-xtip .x{position:absolute;top:4px;right:7px;cursor:pointer;color:var(--g-muted);font-size:10px}\n@media (prefers-reduced-motion:reduce){#gitl,#gitl *,#gitl::before,#gitl::after{animation:none!important}}\n@keyframes gfloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-1.5px)}}
+@keyframes gin{from{opacity:0;transform:translateY(5px) scale(.985)}}
+#gitl.g-enter{animation:gin .18s ease-out}
+#gitl{position:fixed;z-index:2147483647;width:268px;max-width:calc(100vw - 16px);background:var(--g-bg);border:1px solid var(--g-border);
+  border-radius:var(--g-radius);padding:10px 12px;font:11.5px var(--g-font);
+  color:var(--g-text);box-shadow:var(--g-shadow);user-select:none;transition:width .2s}
 #gitl *{box-sizing:border-box}
 #gitl.collapsed .g-body{display:none} #gitl.collapsed{width:auto;min-width:180px}
-.g-body{max-height:min(52vh,380px);overflow-y:auto;overflow-x:hidden;scrollbar-width:thin;scrollbar-color:#2e2f35 transparent}
-.g-body::-webkit-scrollbar{width:4px}.g-body::-webkit-scrollbar-thumb{background:#2e2f35;border-radius:2px}
-.g-adv{width:100%;padding:4px 0;margin:4px 0;border:none;border-top:1px dashed #27282e;background:transparent;color:#555;font-size:9px;cursor:pointer;text-align:center;font-family:inherit;font-weight:600}
-.g-adv:hover{color:#888}
+.g-body{max-height:min(52vh,380px);overflow-y:auto;overflow-x:hidden;scrollbar-width:thin;scrollbar-color:var(--g-border-2) transparent}
+.g-body::-webkit-scrollbar{width:4px}.g-body::-webkit-scrollbar-thumb{background:var(--g-border-2);border-radius:2px}
+.g-adv{width:100%;padding:4px 0;margin:4px 0;border:none;border-top:1px dashed var(--g-border);background:transparent;color:var(--g-text-dim);font-size:9px;cursor:pointer;text-align:center;font-family:inherit;font-weight:600}
+.g-adv:hover{color:var(--g-text-mid)}
+.g-mod{border:1px solid var(--g-border);border-radius:8px;background:var(--g-surface-2);margin:5px 0;overflow:hidden}
+.g-mod-h{display:flex;align-items:center;gap:5px;padding:3px 7px;background:var(--g-surface-3);border-bottom:1px solid var(--g-border);font-size:8.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--g-text-mid)}
+.g-mod-i{font-size:10px;filter:grayscale(.25)}
+.g-mod-x{margin-left:auto;font-weight:600;letter-spacing:0;text-transform:none;color:var(--g-text-low);font-size:8.5px;max-width:58%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.g-mod .g-btns,.g-mod .g-prog,.g-mod .g-row,.g-mod .g-hint,.g-mod .g-posture-wrap{margin:0;padding:5px 7px}
+.g-mod .g-hint{padding-top:0}
+.g-mod-transport .g-btns{gap:5px}
+.g-swatches{display:flex;gap:5px;margin:2px 0 6px}
+.g-swatch{width:15px;height:15px;border-radius:50%;border:1px solid rgba(255,255,255,.25);cursor:pointer;padding:0;flex-shrink:0}
+.g-swatch:hover{transform:scale(1.15)}
+.g-xlist{display:flex;flex-direction:column;gap:5px;margin:6px 0}
+.g-xrow{display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:9px;cursor:pointer;background:var(--g-surface-2);box-shadow:inset 0 1px 3px rgba(0,0,0,.45),inset 0 -1px 0 rgba(255,255,255,.02);border-left:3px solid transparent;transition:background .15s}
+.g-xrow:hover{background:var(--g-hover)}
+.g-xrow:active{box-shadow:inset 0 2px 5px rgba(0,0,0,.55)}
+.g-xicon{flex-shrink:0;width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:12px;border-radius:6px;background:var(--g-surface-3)}
+.g-xtext{display:flex;flex-direction:column;gap:1px;min-width:0}
+.g-xtext b{font-size:10.5px;color:var(--g-text)}
+.g-xtext span{font-size:8.5px;color:var(--g-text-mid);line-height:1.3}
+.g-xrow-accent{border-left-color:var(--g-accent)}.g-xrow-accent .g-xicon{color:var(--g-accent-text)}
+.g-xrow-ok{border-left-color:var(--g-ok)}.g-xrow-ok .g-xicon{color:var(--g-ok)}
+.g-xrow-warn{border-left-color:var(--g-warn)}.g-xrow-warn .g-xicon{color:var(--g-warn)}
+.g-xrow-muted{border-left-color:var(--g-muted)}.g-xrow-muted .g-xicon{color:var(--g-muted)}
 .g-hdr{display:flex;justify-content:space-between;align-items:center;cursor:grab;padding:2px 0;margin-bottom:6px}
 .g-hdr:active{cursor:grabbing}
-.g-logo{font-weight:800;font-size:10.5px;text-transform:uppercase;color:#555;letter-spacing:.6px;display:flex;align-items:center;gap:5px}
+.g-logo{font-weight:800;font-size:10.5px;text-transform:uppercase;color:var(--g-text-dim);letter-spacing:.6px;display:flex;align-items:center;gap:5px}
 .g-dot{display:inline-block;width:7px;height:7px;border-radius:50%;transition:all .3s}
-.g-dot.run{background:#34d399;box-shadow:0 0 5px #34d399;animation:gpulse 1.4s infinite}
-.g-dot.pause{background:#fbbf24}.g-dot.done{background:#818cf8}.g-dot.err{background:#f87171}.g-dot.idle{background:#555}
+.g-dot.run{background:var(--g-ok);box-shadow:0 0 5px var(--g-ok);animation:gpulse 1.4s infinite}
+.g-dot.pause{background:var(--g-warn)}.g-dot.done{background:var(--g-accent)}.g-dot.err{background:var(--g-err)}.g-dot.idle{background:var(--g-text-dim)}
 @keyframes gpulse{0%,100%{opacity:1}50%{opacity:.4}}
-.g-plat{font-size:9.5px;background:#1c1d22;padding:2px 6px;border-radius:4px;color:#818cf8;font-weight:600;border:1px solid #2a2b33}
-.g-minbtn{background:#18191c;border:1px solid #2e2f35;color:#888;font-size:10px;cursor:pointer;padding:1px 6px;border-radius:4px;font-weight:700;transition:all .15s}
+.g-plat{font-size:9.5px;background:var(--g-surface-3);padding:2px 6px;border-radius:4px;color:var(--g-accent);font-weight:600;border:1px solid #2a2b33}
+.g-minbtn{background:var(--g-surface);border:1px solid var(--g-border-2);color:var(--g-text-mid);font-size:10px;cursor:pointer;padding:1px 6px;border-radius:4px;font-weight:700;transition:all .15s}
 .g-minbtn.spin{animation:gvspin .6s linear}
-.g-minbtn:hover{background:#27282e;color:#fff}
+.g-minbtn:hover{background:var(--g-border);color:var(--g-text-hot)}
 .g-coll-row{display:none;align-items:center;gap:6px;margin-top:4px}
 #gitl.collapsed .g-coll-row{display:flex}
-.g-qbtn{width:34px;height:26px;border:1px solid #27282e;border-radius:6px;font-size:13px;cursor:pointer;transition:all .15s}
-.g-qbtn.play{background:#052e1c;color:#34d399;border-color:#064e3b}.g-qbtn.pause{background:#2d1900;color:#fbbf24;border-color:#78350f}
+.g-qbtn{width:34px;height:26px;border:1px solid var(--g-border);border-radius:6px;font-size:13px;cursor:pointer;transition:all .15s}
+.g-qbtn.play{background:var(--g-ok-bg);color:var(--g-ok);border-color:var(--g-ok-deep)}.g-qbtn.pause{background:#2d1900;color:var(--g-warn);border-color:#78350f}
 .g-qstat{font-size:10px;font-weight:700}
-.g-proj{display:flex;align-items:center;gap:5px;margin-bottom:7px;padding:5px 7px;background:#16171b;border:1px solid #27282e;border-radius:7px}
-.g-proj-lbl{font-size:9px;color:#444;flex-shrink:0}
-.g-proj-in{flex:1;background:transparent;border:none;color:#a5b4fc;font-size:10px;font-family:inherit;font-weight:600;outline:none;min-width:0}
-.g-proj-in::placeholder{color:#333}
+.g-proj{display:flex;align-items:center;gap:5px;margin-bottom:7px;padding:5px 7px;background:var(--g-surface-2);border:1px solid var(--g-border);border-radius:7px}
+.g-proj-lbl{font-size:9px;color:var(--g-text-faint);flex-shrink:0}
+.g-proj-in{flex:1;background:transparent;border:none;color:var(--g-accent-text);font-size:10px;font-family:inherit;font-weight:600;outline:none;min-width:0}
+.g-proj-in::placeholder{color:var(--g-text-ghost)}
 .g-tabs{display:flex;gap:3px;margin-bottom:8px}
-.g-tab{flex:1;padding:4px 0;border:1px solid #27282e;border-radius:5px;background:#18191c;color:#555;font-size:8.5px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
-.g-tab:hover{background:#222329;color:#888}.g-tab.act{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
+.g-tab{flex:1;padding:4px 0;border:1px solid var(--g-border);border-radius:5px;background:var(--g-surface);color:var(--g-text-dim);font-size:8.5px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
+.g-tab:hover{background:var(--g-hover);color:var(--g-text-mid)}.g-tab.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
 #g-tc{position:relative}
-.g-tabhelp{position:absolute;top:-2px;right:0;width:16px;height:16px;line-height:14px;text-align:center;border:1px solid #2e2f35;border-radius:50%;background:#16171b;color:#6b7280;font-size:10px;font-weight:700;cursor:pointer;font-family:inherit;padding:0;z-index:3}
-.g-tabhelp:hover{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
+.g-tabhelp{position:absolute;top:-2px;right:0;width:16px;height:16px;line-height:14px;text-align:center;border:1px solid var(--g-border-2);border-radius:50%;background:var(--g-surface-2);color:var(--g-muted);font-size:10px;font-weight:700;cursor:pointer;font-family:inherit;padding:0;z-index:3}
+.g-tabhelp:hover{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
 .g-modes{display:flex;gap:3px;margin-bottom:6px}
-.g-md{flex:1;padding:5px 0;border:1px solid #27282e;border-radius:6px;background:#18191c;color:#666;font-size:9px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
-.g-md:hover{background:#222329}.g-md.act{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
-.g-hint{font-size:9px;color:#484a57;margin-bottom:7px;padding:4px 6px;background:#16171b;border-radius:4px;border-left:2px solid #27282e;line-height:1.4}
+.g-md{flex:1;padding:5px 0;border:1px solid var(--g-border);border-radius:6px;background:var(--g-surface);color:var(--g-text-low);font-size:9px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
+.g-md:hover{background:var(--g-hover)}.g-md.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
+.g-hint{font-size:9px;color:#484a57;margin-bottom:7px;padding:4px 6px;background:var(--g-surface-2);border-radius:4px;border-left:2px solid var(--g-border);line-height:1.4}
 .g-posture-wrap{margin-bottom:7px}
 .g-posture-lbl{font-size:8.5px;text-transform:uppercase;letter-spacing:.5px;color:#4a4d57;font-weight:600;margin-bottom:3px;display:flex;align-items:center;gap:5px}
-.g-posture-q{width:14px;height:14px;line-height:12px;text-align:center;border:1px solid #2e2f35;border-radius:50%;background:#16171b;color:#6b7280;font-size:9px;font-weight:700;cursor:pointer;font-family:inherit;padding:0}
-.g-posture-q:hover{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
+.g-posture-q{width:14px;height:14px;line-height:12px;text-align:center;border:1px solid var(--g-border-2);border-radius:50%;background:var(--g-surface-2);color:var(--g-muted);font-size:9px;font-weight:700;cursor:pointer;font-family:inherit;padding:0}
+.g-posture-q:hover{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
 .g-postures{display:flex;gap:3px}
-.g-pst{flex:1;padding:5px 0;border:1px solid #27282e;border-radius:6px;background:#18191c;color:#666;font-size:9px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
-.g-pst:hover{background:#222329}.g-pst.act{background:#1f1a2e;border-color:#6d28d9;color:#c4b5fd}
+.g-pst{flex:1;padding:5px 0;border:1px solid var(--g-border);border-radius:6px;background:var(--g-surface);color:var(--g-text-low);font-size:9px;cursor:pointer;text-align:center;font-weight:600;transition:all .15s;font-family:inherit}
+.g-pst:hover{background:var(--g-hover)}.g-pst.act{background:#1f1a2e;border-color:#6d28d9;color:#c4b5fd}
 .g-posture-hint{font-size:8.5px;color:#5a5d68;line-height:1.4;margin-top:4px;padding:3px 6px;background:#141519;border-radius:4px;border-left:2px solid #3a2e5a}
 .g-btns{display:flex;gap:3px;margin-bottom:7px}
-.g-btn{flex:1;padding:7px 0;border:1px solid #27282e;border-radius:7px;background:#18191c;color:#999;font-size:14px;cursor:pointer;text-align:center;transition:all .15s;font-family:inherit}
-.g-btn:hover{background:#222329}
-.g-btn.go{background:#052e1c;border-color:#064e3b;color:#34d399}.g-btn.go:hover{background:#064e3b}
-.g-btn.st{background:#2d0a0a;border-color:#7f1d1d;color:#f87171}.g-btn.st:hover{background:#7f1d1d}
+.g-btn{flex:1;padding:7px 0;border:1px solid var(--g-border);border-radius:7px;background:var(--g-surface);color:#999;font-size:14px;cursor:pointer;text-align:center;transition:all .15s;font-family:inherit}
+.g-btn:hover{background:var(--g-hover)}
+.g-btn.go{background:var(--g-ok-bg);border-color:var(--g-ok-deep);color:var(--g-ok)}.g-btn.go:hover{background:var(--g-ok-deep)}
+.g-btn.rg{background:#1a1a2e;border-color:#312e81;color:var(--g-accent-text)}.g-btn.rg:hover{background:#312e81}
+.g-dim{opacity:.35;cursor:not-allowed;pointer-events:none}
+.g-plink{color:var(--g-accent);text-decoration:none;font-size:9px;margin-left:4px}.g-plink:hover{text-decoration:underline}
+.g-cust-badge{font-size:8px;color:#f59e0b;font-weight:400}
+.g-btn.st{background:#2d0a0a;border-color:#7f1d1d;color:var(--g-err)}.g-btn.st:hover{background:#7f1d1d}
 .g-prog{margin:2px 0 6px}
-.g-trk{height:5px;background:#1c1d22;border-radius:2px;overflow:hidden}
-.g-fill{height:100%;background:linear-gradient(90deg,#34d399,#818cf8);border-radius:2px;transition:width .4s}
+.g-trk{height:5px;background:var(--g-surface-3);border-radius:2px;overflow:hidden}
+.g-fill{height:100%;background:linear-gradient(90deg,var(--g-ok),var(--g-accent));border-radius:2px;transition:width .4s}
 .g-plbl{display:flex;justify-content:space-between;align-items:baseline;margin-top:3px}
-.g-step{font-size:11px;color:#c9cad0}.g-step b{font-size:13px;color:#e7e7ea;font-weight:700}
+.g-step{font-size:11px;color:var(--g-text)}.g-step b{font-size:13px;color:#e7e7ea;font-weight:700}
 .g-step-pct{font-size:10px;color:#777}
 .g-safety{margin-top:6px;padding:5px 7px;background:#141519;border:1px solid #20212a;border-radius:6px}
 .g-safety-row{display:flex;align-items:center;gap:6px;font-size:8.5px}
 .g-safety-lbl{color:#4a4d57;text-transform:uppercase;letter-spacing:.5px;font-weight:600}
-.g-safety-num{margin-left:auto;color:#6b7280}.g-safety-num b{color:#9ca3af}
-.g-safety-rst{flex:0 0 auto;width:16px;height:16px;line-height:14px;text-align:center;border:1px solid #2a2c35;border-radius:4px;background:#16171b;color:#6b7280;font-size:10px;cursor:pointer;font-family:inherit;padding:0}
-.g-safety-rst:hover{background:#1c1d22;color:#a5b4fc;border-color:#3730a3}
-.g-safety-trk{height:2px;background:#1c1d22;border-radius:1px;overflow:hidden;margin-top:4px}
+.g-safety-num{margin-left:auto;color:var(--g-muted)}.g-safety-num b{color:#9ca3af}
+.g-safety-rst{flex:0 0 auto;width:16px;height:16px;line-height:14px;text-align:center;border:1px solid #2a2c35;border-radius:4px;background:var(--g-surface-2);color:var(--g-muted);font-size:10px;cursor:pointer;font-family:inherit;padding:0}
+.g-safety-rst:hover{background:var(--g-surface-3);color:var(--g-accent-text);border-color:var(--g-accent-deep)}
+.g-safety-trk{height:2px;background:var(--g-surface-3);border-radius:1px;overflow:hidden;margin-top:4px}
 .g-safety-fill{height:100%;background:#3a3d47;border-radius:1px;transition:width .4s}
 .g-safety.warn{border-color:#5a4420;background:#1f1808}
 .g-safety.warn .g-safety-num b,.g-safety.warn .g-safety-lbl{color:#fcd34d}
 .g-safety.warn .g-safety-fill{background:#f59e0b}
-.g-stat{text-align:center;font-weight:600;font-size:10.5px;padding:4px 0;border-top:1px solid #1c1d22;margin-top:2px}
-.g-row{display:flex;align-items:center;justify-content:space-between;font-size:10px;color:#666;margin-bottom:5px}
-.g-row label{color:#555}
-.g-row input[type="number"],.g-row input[type="text"]{background:#18191c;border:1px solid #2e2f35;border-radius:4px;color:#c9cad0;font-size:10px;padding:2px 5px;font-family:inherit}
+.g-safety.off{opacity:.5;border-color:var(--g-surface-3)}
+.g-safety.off .g-safety-lbl{color:var(--g-text-dim)}
+.g-safety-edit{width:42px;background:var(--g-bg-deep);border:1px solid var(--g-border-2);border-radius:4px;color:var(--g-text);font-size:10px;text-align:center;font-family:inherit;padding:2px 3px;margin-left:4px}
+.g-safety-edit:focus{border-color:#4338ca;outline:none}
+.g-stat{text-align:center;font-weight:600;font-size:10.5px;padding:4px 0;border-top:1px solid var(--g-surface-3);margin-top:2px}
+.g-row{display:flex;align-items:center;justify-content:space-between;font-size:10px;color:var(--g-text-low);margin-bottom:5px}
+.g-row label{color:var(--g-text-dim)}
+.g-row input[type="number"],.g-row input[type="text"]{background:var(--g-surface);border:1px solid var(--g-border-2);border-radius:4px;color:var(--g-text);font-size:10px;padding:2px 5px;font-family:inherit}
 .g-row input[type="number"]{width:52px;text-align:center}.g-row input[type="text"]{width:110px}
 .g-row input:focus{outline:none;border-color:#4338ca}
-.g-row select{background:#18191c;border:1px solid #2e2f35;border-radius:4px;color:#c9cad0;font-size:10px;padding:2px 4px;font-family:inherit}
-.g-tog{width:28px;height:14px;background:#2e2f35;border-radius:7px;position:relative;cursor:pointer;transition:background .2s;flex-shrink:0}
-.g-tog.on{background:#064e3b}
-.g-tog::after{content:'';width:10px;height:10px;background:#666;border-radius:50%;position:absolute;top:2px;left:2px;transition:left .2s,background .2s}
-.g-tog.on::after{left:16px;background:#34d399}
+.g-row select{background:var(--g-surface);border:1px solid var(--g-border-2);border-radius:4px;color:var(--g-text);font-size:10px;padding:2px 4px;font-family:inherit}
+.g-tog{width:28px;height:14px;background:var(--g-border-2);border-radius:7px;position:relative;cursor:pointer;transition:background .2s;flex-shrink:0}
+.g-tog.on{background:var(--g-ok-deep)}
+.g-tog::after{content:'';width:10px;height:10px;background:var(--g-text-low);border-radius:50%;position:absolute;top:2px;left:2px;transition:left .2s,background .2s}
+.g-tog.on::after{left:16px;background:var(--g-ok)}
 .g-pos-row{display:flex;gap:3px}
-.g-pos{background:#18191c;border:1px solid #2e2f35;color:#777;font-size:11px;width:22px;height:20px;cursor:pointer;border-radius:4px;display:flex;align-items:center;justify-content:center;transition:all .15s}
-.g-pos:hover{background:#27282e;color:#fff}.g-pos.act{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
-.g-exp-btn{width:100%;padding:8px;background:#052e1c;border:1px solid #064e3b;border-radius:7px;color:#34d399;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;margin-top:2px;text-align:center;transition:all .15s}
-.g-exp-btn:hover{background:#064e3b}
-.g-div{height:1px;background:#1c1d22;margin:7px 0}
-.g-diag{font-size:9px;color:#444;line-height:1.6;padding:5px 6px;background:#0c0d10;border:1px solid #27282e;border-radius:5px;max-height:200px;overflow-y:auto;white-space:pre-wrap;word-break:break-all}
-.g-sites{width:100%;box-sizing:border-box;background:#0c0d10;border:1px solid #27282e;border-radius:5px;color:#9aa;font-size:9px;font-family:monospace;padding:5px 6px;margin-bottom:4px;resize:vertical}
-.g-btn-sm{padding:3px 8px;margin-top:5px;border:1px solid #3730a3;border-radius:5px;background:#1a1b2e;color:#a5b4fc;font-size:9px;cursor:pointer;font-family:inherit;font-weight:600}
+.g-pos{background:var(--g-surface);border:1px solid var(--g-border-2);color:#777;font-size:11px;width:22px;height:20px;cursor:pointer;border-radius:4px;display:flex;align-items:center;justify-content:center;transition:all .15s}
+.g-pos:hover{background:var(--g-border);color:var(--g-text-hot)}.g-pos.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
+.g-exp-btn{width:100%;padding:8px;background:var(--g-ok-bg);border:1px solid var(--g-ok-deep);border-radius:7px;color:var(--g-ok);font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;margin-top:2px;text-align:center;transition:all .15s}
+.g-exp-btn:hover{background:var(--g-ok-deep)}
+.g-div{height:1px;background:var(--g-surface-3);margin:7px 0}
+.g-diag{font-size:9px;color:var(--g-text-faint);line-height:1.6;padding:5px 6px;background:var(--g-bg-deep);border:1px solid var(--g-border);border-radius:5px;max-height:200px;overflow-y:auto;white-space:pre-wrap;word-break:break-all}
+.g-sites{width:100%;box-sizing:border-box;background:var(--g-bg-deep);border:1px solid var(--g-border);border-radius:5px;color:#9aa;font-size:9px;font-family:monospace;padding:5px 6px;margin-bottom:4px;resize:vertical}
+.g-btn-sm{padding:3px 8px;margin-top:5px;border:1px solid var(--g-accent-deep);border-radius:5px;background:var(--g-accent-bg);color:var(--g-accent-text);font-size:9px;cursor:pointer;font-family:inherit;font-weight:600}
 .g-btn-sm:hover{background:#222345}
 .g-qrow{display:flex;align-items:center;gap:5px;margin-bottom:4px}
-.g-qin{flex:1;min-width:0;background:#0c0d10;border:1px solid #27282e;border-radius:5px;color:#aab;font-size:9.5px;padding:4px 6px;font-family:inherit}
-.g-qin:focus{border-color:#3730a3;outline:none}
-.g-qdel{border:none;background:transparent;color:#444;cursor:pointer;font-size:10px;padding:2px}
+.g-qin{flex:1;min-width:0;background:var(--g-bg-deep);border:1px solid var(--g-border);border-radius:5px;color:#aab;font-size:9.5px;padding:4px 6px;font-family:inherit}
+.g-qin:focus{border-color:var(--g-accent-deep);outline:none}
+.g-qdel{border:none;background:transparent;color:var(--g-text-faint);cursor:pointer;font-size:10px;padding:2px}
 .g-qdel:hover{color:#e66}
 .g-qtext{flex:1;font-size:9.5px;color:#999;line-height:1.4;word-break:break-word}
 .g-qtext.done{color:#4a5;text-decoration:line-through;text-decoration-color:#2a3}
 .g-hpills{display:flex;flex-wrap:wrap;gap:3px;margin-bottom:7px}
-.g-hpill{padding:3px 7px;border:1px solid #27282e;border-radius:10px;background:#18191c;color:#666;font-size:8.5px;cursor:pointer;font-family:inherit;font-weight:600}
-.g-hpill.act{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
-.g-support{text-align:center;font-size:8px;color:#3a3b40;margin-top:8px;padding-top:6px;border-top:1px solid #1c1d22}
+.g-hpill{padding:3px 7px;border:1px solid var(--g-border);border-radius:10px;background:var(--g-surface);color:var(--g-text-low);font-size:8.5px;cursor:pointer;font-family:inherit;font-weight:600}
+.g-hpill.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
+.g-support{text-align:center;font-size:8px;color:#3a3b40;margin-top:8px;padding-top:6px;border-top:1px solid var(--g-surface-3)}
 .g-support a{color:#4a4b55;text-decoration:none}
-.g-support a:hover{color:#a5b4fc}
+.g-support a:hover{color:var(--g-accent-text)}
 #gitl-veil{position:fixed;inset:0;z-index:2147483646;display:none;align-items:center;justify-content:center;background:rgba(8,9,12,.62);backdrop-filter:blur(2px);font-family:-apple-system,'Segoe UI',Roboto,sans-serif;border:none;padding:0;margin:0;width:100vw;height:100vh;max-width:none;max-height:none;overflow:hidden}
 /* Popover top-layer mode: renders above ALL host stacking contexts */
 #gitl-veil:popover-open{display:flex}
 #gitl-veil::backdrop{background:rgba(8,9,12,.62);backdrop-filter:blur(2px)}
-.gv-card{position:relative;background:#111214;border:1px solid #27282e;border-radius:14px;padding:22px 26px;width:240px;text-align:center;box-shadow:0 12px 48px rgba(0,0,0,.6);z-index:1}
+.gv-card{position:relative;background:var(--g-bg);border:1px solid var(--g-border);border-radius:14px;padding:22px 26px;width:240px;text-align:center;box-shadow:0 12px 48px rgba(0,0,0,.6);z-index:1}
 /* ── Ghost field (3D-ish parallax). Compositor-only transforms — no JS loop. */
 .gv-ringwrap{position:relative;width:96px;height:72px;margin:0 auto 12px;perspective:340px;transform-style:preserve-3d}
-.gv-ring{position:absolute;top:4px;left:50%;width:60px;height:60px;margin-left:-30px;border:3px solid #25262c;border-top-color:#a5b4fc;border-radius:50%;animation:gvspin 1s linear infinite;opacity:.9}
+.gv-ring{position:absolute;top:4px;left:50%;width:60px;height:60px;margin-left:-30px;border:3px solid #25262c;border-top-color:var(--g-accent-text);border-radius:50%;animation:gvspin 1s linear infinite;opacity:.9}
 .gv-ghost{position:absolute;top:50%;left:50%;font-size:30px;line-height:1;transform:translate(-50%,-50%);animation:gvbob 2s ease-in-out infinite;filter:drop-shadow(0 4px 6px rgba(0,0,0,.5));z-index:2}
 /* extra ghosts only appear in full-motion mode */
 .gv-ghost-x{position:absolute;top:50%;left:50%;font-size:18px;line-height:1;opacity:0;pointer-events:none;will-change:transform,opacity}
@@ -2553,67 +3452,83 @@ function injectStyles() {
   .gv-ring{animation:gvspin 1.4s linear infinite} }
 .gv-title{color:#e7e7ea;font-size:12px;font-weight:700;margin-bottom:8px}
 .gv-steps{text-align:left;margin:0 auto 10px;display:inline-block}
-.gv-step{font-size:9.5px;color:#555;line-height:1.8}
-.gv-step.act{color:#a5b4fc}.gv-step.done{color:#4a5}
-.gv-barwrap{height:5px;background:#1c1d22;border-radius:3px;overflow:hidden;margin-bottom:5px}
-.gv-bar{height:100%;background:linear-gradient(90deg,#6366f1,#a5b4fc);border-radius:3px;width:0;transition:width .25s}
+.gv-step{font-size:9.5px;color:var(--g-text-dim);line-height:1.8}
+.gv-step.act{color:var(--g-accent-text)}.gv-step.done{color:#4a5}
+.gv-barwrap{height:5px;background:var(--g-surface-3);border-radius:3px;overflow:hidden;margin-bottom:5px}
+.gv-bar{height:100%;background:linear-gradient(90deg,#6366f1,var(--g-accent-text));border-radius:3px;width:0;transition:width .25s}
 .gv-bar.indet{animation:gvslide 1.2s ease-in-out infinite}
 @keyframes gvslide{0%{margin-left:-40%}100%{margin-left:100%}}
 .gv-pct{font-size:9px;color:#777;height:12px;margin-bottom:6px}
-.gv-note{font-size:8.5px;color:#666;margin-bottom:10px}
+.gv-note{font-size:8.5px;color:var(--g-text-low);margin-bottom:10px}
 .gv-cancel{padding:4px 14px;border:1px solid #3a2a2a;border-radius:6px;background:#1c1416;color:#c88;font-size:9px;cursor:pointer;font-family:inherit}
 .gv-cancel:hover{background:#241719}
 #gitl.pos-dock{border-radius:10px 0 0 10px;border-right:none;width:268px}
-#gitl.pos-dock.collapsed{width:32px!important;min-width:0}
+#gitl.pos-dock.collapsed{width:44px!important;min-width:0}
 #gitl.pos-dock.collapsed .g-hdr{flex-direction:column;padding:10px 4px;gap:6px}
 #gitl.pos-dock.collapsed .g-hdr > span:last-child{flex-direction:column}
 #gitl.pos-dock.collapsed .g-plat{display:none}
+#gitl.pos-dock.collapsed .g-minbtn:not(#g-col){display:none}
+#gitl.pos-dock.collapsed #g-col{font-size:14px;padding:4px 8px}
 #gitl.pos-dock.collapsed .g-logo{writing-mode:vertical-rl;font-size:11px}
-#gitl.pos-dock.collapsed .g-coll-row{flex-direction:column;padding:4px 2px}
+#gitl.pos-dock.collapsed .g-coll-row{flex-direction:column;padding:4px 2px;gap:6px}
+#gitl.pos-dock.collapsed .g-qbtn{width:36px;height:36px;font-size:16px;border-radius:8px}
 #gitl.pos-dock.collapsed .g-qstat{display:none}
+.g-dock-stat{display:none;font-size:9px;font-weight:700;text-align:center;color:var(--g-text-mid);line-height:1.2;word-break:break-all}
+#gitl.pos-dock.collapsed .g-dock-stat,#gitl.pos-dock-left.collapsed .g-dock-stat{display:block}
+.g-dk-drift{display:flex;flex-direction:column;align-items:center;gap:2px;margin-top:3px}
+.g-dk-cap{font-size:7.5px;color:var(--g-text-low);letter-spacing:.02em}
+.g-dk-bar{display:block;width:32px;height:4px;margin:0 auto 3px;background:var(--g-surface-3);border-radius:2px;overflow:hidden}
+.g-dk-bar i{display:block;height:100%;background:linear-gradient(90deg,var(--g-ok),var(--g-accent));border-radius:2px;transition:width .4s}
+.g-dk-edit{width:34px;height:18px;background:var(--g-bg-deep);border:1px solid var(--g-border-2);border-radius:3px;color:var(--g-text);font-size:9px;text-align:center;font-family:inherit;padding:0}
+.g-dk-edit:focus{border-color:#4338ca;outline:none}
+.g-dk-rst{background:var(--g-surface);border:1px solid var(--g-border-2);color:var(--g-text-mid);font-size:10px;cursor:pointer;padding:1px 6px;border-radius:3px;line-height:1}
+.g-dk-rst:hover{background:var(--g-border);color:var(--g-text-hot)}
 /* Gold left-dock: mirror geometry to the left edge + gold accents. Our own
    element in the top stacking context — never injected into the host's menu. */
 #gitl.pos-dock-left{left:0;right:auto;border-radius:0 10px 10px 0;border-left:none;border-right:1px solid #5a4a1e}
 #gitl.pos-dock-left.collapsed .g-hdr{flex-direction:column;padding:10px 4px;gap:6px}
+#gitl.pos-dock-left.collapsed .g-minbtn:not(#g-col){display:none}
+#gitl.pos-dock-left.collapsed #g-col{font-size:14px;padding:4px 8px}
 #gitl.pos-dock-left{border-color:#5a4a1e;box-shadow:0 10px 32px rgba(120,90,10,.28)}
 #gitl.pos-dock-left .g-logo{color:#e8c66a}
 #gitl.pos-dock-left.collapsed .g-logo{writing-mode:vertical-rl;font-size:13px;color:#f0cd6e;letter-spacing:1px}
+#gitl.pos-dock-left.collapsed .g-qbtn{width:36px;height:36px;font-size:16px;border-radius:8px}
 #gitl.pos-dock-left .g-dot{box-shadow:0 0 6px rgba(232,198,106,.6)}
 .g-pos-gold{color:#e8c66a!important}
 .g-pos-gold.act{background:#2a2410!important;border-color:#5a4a1e!important}
-.g-diag .ok{color:#34d399}.g-diag .warn{color:#f87171}
-.g-persona-btn{width:100%;text-align:left;padding:5px 7px;margin-bottom:3px;border:1px solid #27282e;border-radius:6px;background:#18191c;color:#c9cad0;font-family:inherit;font-size:10px;cursor:pointer;transition:all .15s}
-.g-persona-btn.act{background:#1a1b2e;border-color:#3730a3;color:#c7d2fe}
-.g-persona-btn .plbl{font-weight:700;color:#9ca3af}.g-persona-btn.act .plbl{color:#a5b4fc}
-.g-persona-btn .pdesc{font-size:9px;color:#6b7280;line-height:1.4;margin-top:1px}
+.g-diag .ok{color:var(--g-ok)}.g-diag .warn{color:var(--g-err)}
+.g-persona-btn{width:100%;text-align:left;padding:5px 7px;margin-bottom:3px;border:1px solid var(--g-border);border-radius:6px;background:var(--g-surface);color:var(--g-text);font-family:inherit;font-size:10px;cursor:pointer;transition:all .15s}
+.g-persona-btn.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:#c7d2fe}
+.g-persona-btn .plbl{font-weight:700;color:#9ca3af}.g-persona-btn.act .plbl{color:var(--g-accent-text)}
+.g-persona-btn .pdesc{font-size:9px;color:var(--g-muted);line-height:1.4;margin-top:1px}
 .g-cust-badge{color:#e8c66a;font-size:9px}
 .g-del{float:right;color:#7a5050;font-size:10px;padding:0 3px;border-radius:3px;cursor:pointer}
 .g-del:hover{background:#3a1f1f;color:#e0a0a0}
-.g-ws-bar{display:flex;gap:5px;margin-top:8px;padding-top:7px;border-top:1px solid #1c1d22}
-.g-ws-btn{flex:1;padding:5px 0;border:1px solid #2a2c35;border-radius:5px;background:#16171b;color:#8b8ea3;font-size:9px;font-weight:600;cursor:pointer;font-family:inherit}
-.g-ws-btn:hover{background:#1a1b2e;border-color:#3730a3;color:#a5b4fc}
+.g-ws-bar{display:flex;gap:5px;margin-top:8px;padding-top:7px;border-top:1px solid var(--g-surface-3)}
+.g-ws-btn{flex:1;padding:5px 0;border:1px solid #2a2c35;border-radius:5px;background:var(--g-surface-2);color:#8b8ea3;font-size:9px;font-weight:600;cursor:pointer;font-family:inherit}
+.g-ws-btn:hover{background:var(--g-accent-bg);border-color:var(--g-accent-deep);color:var(--g-accent-text)}
 .g-ws-form{margin-top:6px;padding:7px;background:#141519;border:1px solid #2a2c35;border-radius:6px}
-.g-ws-in,.g-ws-ta{width:100%;margin-bottom:5px;padding:5px 6px;background:#0e0f12;border:1px solid #2a2c35;border-radius:4px;color:#c9cad0;font-family:inherit;font-size:9.5px;box-sizing:border-box}
+.g-ws-in,.g-ws-ta{width:100%;margin-bottom:5px;padding:5px 6px;background:#0e0f12;border:1px solid #2a2c35;border-radius:4px;color:var(--g-text);font-family:inherit;font-size:9.5px;box-sizing:border-box}
 .g-ws-ta{resize:vertical;line-height:1.4}
 .g-ws-form-btns{display:flex;gap:5px}.g-ws-form-btns .g-btn-sm{flex:1;margin-top:0}
-.g-wf-desc{font-size:9px;color:#7a7d88;line-height:1.45;background:#16171b;border:1px solid #27282e;border-radius:5px;padding:6px;margin-bottom:7px}
+.g-wf-desc{font-size:9px;color:#7a7d88;line-height:1.45;background:var(--g-surface-2);border:1px solid var(--g-border);border-radius:5px;padding:6px;margin-bottom:7px}
 .g-wf-how{font-size:9px;color:#9ca3af;line-height:1.5;background:#16171f;border:1px solid #2a2c3a;border-radius:6px;padding:7px 8px;margin-bottom:8px}
 .g-wf-how b{color:#c7d2fe}
 .g-wf-start{width:100%;font-size:12px;padding:8px 0;margin-bottom:2px}
 .g-wf-start.g-dim{opacity:.4;cursor:default}
-.g-wf-progress{font-size:9px;color:#7a7d88;text-align:center;margin:6px 0 2px}.g-wf-progress b{color:#a5b4fc}
-.g-wf-stage{display:flex;align-items:stretch;gap:6px;padding:5px 6px;margin-bottom:3px;background:#16171b;border:1px solid #27282e;border-radius:5px}
+.g-wf-progress{font-size:9px;color:#7a7d88;text-align:center;margin:6px 0 2px}.g-wf-progress b{color:var(--g-accent-text)}
+.g-wf-stage{display:flex;align-items:stretch;gap:6px;padding:5px 6px;margin-bottom:3px;background:var(--g-surface-2);border:1px solid var(--g-border);border-radius:5px}
 .g-wf-stage-txt{flex:1;font-size:9px;line-height:1.45;color:#7a7d88}
-.g-wf-stage b{color:#8b8ea3}.g-wf-stage.act{background:#1a1b2e;border-color:#3730a3}.g-wf-stage.act .g-wf-stage-txt,.g-wf-stage.act b{color:#c7d2fe}
-.g-wf-ins{flex:0 0 auto;width:20px;border:1px solid #3730a3;border-radius:4px;background:#1a1b2e;color:#a5b4fc;font-size:8px;font-weight:700;letter-spacing:.5px;cursor:pointer;font-family:inherit;writing-mode:vertical-rl;text-orientation:mixed;padding:4px 0;transition:all .15s}
+.g-wf-stage b{color:#8b8ea3}.g-wf-stage.act{background:var(--g-accent-bg);border-color:var(--g-accent-deep)}.g-wf-stage.act .g-wf-stage-txt,.g-wf-stage.act b{color:#c7d2fe}
+.g-wf-ins{flex:0 0 auto;width:20px;border:1px solid var(--g-accent-deep);border-radius:4px;background:var(--g-accent-bg);color:var(--g-accent-text);font-size:8px;font-weight:700;letter-spacing:.5px;cursor:pointer;font-family:inherit;writing-mode:vertical-rl;text-orientation:mixed;padding:4px 0;transition:all .15s}
 .g-wf-ins:hover{background:#26284a}
 .g-wf-ins.ins-ok{background:#14532d;border-color:#16a34a;color:#86efac}
-.g-peek-btn{font-size:9px;color:#3a3b44;cursor:pointer;text-align:center;margin-top:5px;padding-top:4px;border-top:1px solid #1c1d22}
+.g-peek-btn{font-size:9px;color:#3a3b44;cursor:pointer;text-align:center;margin-top:5px;padding-top:4px;border-top:1px solid var(--g-surface-3)}
 .g-peek-btn:hover{color:#777}
-.g-peek{display:none;margin-top:4px;padding:5px;background:#0c0d10;border:1px solid #27282e;border-radius:5px;font-size:9px;line-height:1.5;color:#48505e;white-space:pre-wrap;max-height:140px;overflow-y:auto}
+.g-peek{display:none;margin-top:4px;padding:5px;background:var(--g-bg-deep);border:1px solid var(--g-border);border-radius:5px;font-size:9px;line-height:1.5;color:#48505e;white-space:pre-wrap;max-height:140px;overflow-y:auto}
 .g-peek.open{display:block}
-.g-shortcuts{font-size:8.5px;color:#333;text-align:center;margin-top:4px}
-.g-firstrun{padding:6px 8px;background:#1a1b2e;border:1px solid #3730a3;border-radius:6px;font-size:9.5px;color:#a5b4fc;line-height:1.4;margin-bottom:7px;text-align:center}
+.g-shortcuts{font-size:8.5px;color:var(--g-text-ghost);text-align:center;margin-top:4px}
+.g-firstrun{padding:6px 8px;background:var(--g-accent-bg);border:1px solid var(--g-accent-deep);border-radius:6px;font-size:9.5px;color:var(--g-accent-text);line-height:1.4;margin-bottom:7px;text-align:center}
 .g-report{margin-top:6px;padding:7px 9px;background:#241719;border:1px solid #5a2e2e;border-radius:7px}
 .g-report-h{font-size:10px;font-weight:700;color:#f1b4b4;display:flex;align-items:center;gap:6px}
 .g-report-k{font-size:8px;font-weight:600;color:#c88;background:#1c1416;border:1px solid #3a2a2a;border-radius:4px;padding:1px 5px}
@@ -2657,6 +3572,69 @@ function injectStyles() {
 const panel = document.createElement('div');
 panel.id = 'gitl';
 let _panelMounted = false;
+/* ── EXPLAIN MODE (d9) — tap ⓘ, then tap any control for a one-breath answer.
+   Registry-driven; capture-phase intercept swallows the click so nothing fires. */
+const EXPLAIN = [
+  { sel:'#g-play',        name:'▶ Start / Resume',  desc:'Begins (or resumes) the auto-continue loop using the current Strategy and Thinking posture.' },
+  { sel:'#g-pause',       name:'⏸ Pause',           desc:'Stops auto-continuing. The chat is untouched — press ▶ to pick up where you left off.' },
+  { sel:'#g-reground',    name:'⊕ Reground',        desc:'Re-anchors the AI to the ORIGINAL task. Use it the moment answers drift off-topic.' },
+  { sel:'#g-stop',        name:'✕ End & reset',     desc:'Ends the run and resets rounds, roadmap position and workflow stage.' },
+  { sel:'#g-strategy',    name:'Strategy',          desc:'Step by step = one nudge per reply. Plan first = the AI batches a plan, then executes. Autopilot = the AI writes a roadmap and Ghost runs every step.' },
+  { sel:'#g-drift-tog',   name:'Drift guard',       desc:'Auto-pauses after N continues so an unattended run can\u2019t wander. The checkpoint asks: continue, reground, or stop.' },
+  { sel:'#g-drift-max',   name:'Drift limit',       desc:'The N — how many auto-continues before the drift checkpoint fires.' },
+  { sel:'#g-cnt-reset',   name:'↻ Reset counter',   desc:'Resets the used-continues count without ending the run.' },
+  { sel:'#run-adv',       name:'Advanced',          desc:'Power tools: Thinking posture (Locked / Adaptive / Audit), the injected-prompt preview, End & reset, and diagnostics.' },
+  { sel:'#g-posture-help',name:'Thinking posture',  desc:'Controls whether the AI\u2019s plan may grow: Locked = exact plan \u00b7 Adaptive = may add justified steps mid-run \u00b7 Audit = locked plan + one final gap-review.' },
+  { sel:'.g-pst',         name: el => 'Posture: ' + ((POSTURES[el.dataset.pst]||{}).label||''), desc: el => (POSTURES[el.dataset.pst]||{}).desc || '' },
+  { sel:'#g-peek-btn',    name:'What gets injected',desc:'Shows the exact instruction block Ghost appends to your prompt for the current Strategy.' },
+  { sel:'#g-handoff',     name:'🤝 Handoff',        desc:'The AI writes its own briefing for a fresh chat. Best choice while the current chat STILL RESPONDS.' },
+  { sel:'#g-export',      name:'⬇ Export',          desc:'Downloads the full transcript. The complete record of the four export actions — for keeping, not for resuming.' },
+  { sel:'#g-capsule',     name:'💊 Capsule v2',       desc:'A resumable JSON snapshot with dedup + a resume token — built for feeding back into an API or another tool, not for reading.' },
+  { sel:'#g-rescue',      name:'🧷 Backup Handoff',   desc:'Handoff\u2019s calmer, lighter sibling — for when the chat is DEAD and can\u2019t write its own briefing. A state snapshot + the last 10 messages verbatim, enough to resume elsewhere. Smaller than a full export on purpose.' },
+  { sel:'#exp-think',     name:'💭 Thinking logs',  desc:'Include the model\u2019s visible reasoning/thinking sections in the export, on platforms that expose them.' },
+  { sel:'#exp-fmt',       name:'Export format',     desc:'Markdown for humans, JSON for tools.' },
+  { sel:'#cfg-unattended',name:'🌙 Unattended',      desc:'Normally Ghost pauses when you switch tabs, so it can\u2019t burn tokens unwatched. Turn this on to keep running in a background tab \u2014 it also switches to a Worker-based timer that browsers don\u2019t throttle. The tab must stay OPEN; this does not run on a server.' },
+  { sel:'#cfg-skin',      name:'🎨 Skin',           desc:'Visual theme. Skins are pure style tokens — they can never add, remove, or change features.' },
+  { sel:'#cfg-skin-imp',  name:'⬆ Import skin',     desc:'Load a .gitl.json skin file. Anything a skin isn\u2019t allowed to do is silently dropped.' },
+  { sel:'#cfg-skin-exp',  name:'⬇ Export skin',     desc:'Save the active skin as .gitl.json — edit it in any text editor and re-import. That\u2019s the whole modding loop.' },
+  { sel:'#cfg-hue',       name:'Accent hue',        desc:'Tints the active skin\u2019s accent family. Double-click resets to the skin\u2019s own hue.' },
+  { sel:'.g-swatch',      name:'Color swatch',       desc:'One-tap accent colors — same effect as dragging the hue slider to that spot.' },
+  { sel:'.g-tab',         name: el => 'Tab: ' + (el.textContent||'').trim(), desc: () => 'Switches the panel section. The ? button gives the full guide for whichever tab is open.' },
+  { sel:'#g-tabhelp',     name:'? Tab guide',       desc:'Opens the full walkthrough for the current tab.' }
+];
+function _explainLookup(target) {
+  if (!target || !target.closest) return null;
+  for (const e of EXPLAIN) {
+    const hit = target.closest(e.sel);
+    if (hit) return {
+      name: typeof e.name === 'function' ? e.name(hit) : e.name,
+      desc: typeof e.desc === 'function' ? e.desc(hit) : e.desc
+    };
+  }
+  return null;
+}
+function _explainShow(info) {
+  let tip = panel.querySelector('.g-xtip');
+  if (!tip) { tip = document.createElement('div'); tip.className = 'g-xtip'; panel.appendChild(tip); }
+  tip.innerHTML = `<span class="x" id="g-xtip-x">✕</span><b>${info.name}</b><br>${info.desc}`;
+}
+function _explainIntercept(e) {
+  const t = e.target;
+  if (t && t.closest && t.closest('#g-explain-tog')) {
+    e.preventDefault(); e.stopPropagation();
+    GHOST.ui.explain = !GHOST.ui.explain;
+    panel.dataset.explain = GHOST.ui.explain ? '1' : '0';
+    const tip = panel.querySelector('.g-xtip');
+    if (!GHOST.ui.explain) { if (tip) tip.remove(); }
+    else _explainShow({ name:'🔎 Explain mode', desc:'Tap any button or control to see what it does — nothing will activate. Tap ⓘ again to exit.' });
+    return;
+  }
+  if (!GHOST.ui.explain) return;
+  if (t && t.closest && t.closest('#g-xtip-x')) { e.preventDefault(); e.stopPropagation(); const tip = panel.querySelector('.g-xtip'); if (tip) tip.remove(); return; }
+  e.preventDefault(); e.stopPropagation();
+  _explainShow(_explainLookup(t) || { name:'—', desc:'No note for this one yet — the ? button has the full tab guide.' });
+}
+
 function mountPanel() {
   if (_panelMounted || !document.body) return;
   // Defense-in-depth: if a stray #gitl exists (e.g. script eval'd twice in a
@@ -2665,6 +3643,10 @@ function mountPanel() {
   if (existing && existing !== panel) existing.remove();
   _panelMounted = true;
   document.body.appendChild(panel);
+  // Smoother load: 180ms entrance instead of pop-in. Animation-only — ends at
+  // the natural resting state, so nothing downstream can depend on it.
+  try { panel.classList.add('g-enter'); setTimeout(() => panel.classList.remove('g-enter'), 400); } catch(_) {}
+  panel.addEventListener('click', _explainIntercept, true); // capture: explain mode swallows clicks before handlers
 }
 
 /* Escape untrusted text before interpolating into innerHTML templates.
@@ -2697,31 +3679,26 @@ function statLabel() {
 function renderRunTab() {
   const L = GHOST.loop, p = L.lastProgress, pct = p ? Math.round((p.step/p.total)*100) : 0;
   const pm = L.payloadMode;
+  const runAdv = GHOST.ui.runAdv || false;
   const peekOpen = panel.querySelector('.g-peek')?.classList.contains('open');
   const firstRun = GHOST.ui.firstRun;
+  const idle = L.state==='IDLE'||L.state==='COMPLETE';
+  const activeP = (GHOST.persona.selected||[]).filter(s=>s&&s!=='none');
+  const pLabel = activeP.length>1?'Committee: '+activeP.map(s=>(allPersonas()[s]||{}).label||s).join(', '):activeP.length===1?(allPersonas()[activeP[0]]||{}).label||'':'';
   return `
-    ${firstRun ? `<div class="g-firstrun"><b>👻 Quick start</b><br>1. Type your big task in the chat box<br>2. Press ▶ — Ghost wraps it in the loop protocol<br>3. Walk away. Ghost auto-continues, stops on [[GITL::HALT]]<br><button class="g-btn-sm" id="g-onb-done">Got it</button></div>` : ''}
-    <div class="g-modes">
-      <button class="g-md${pm==='loop'?' act':''}" data-m="loop">${PAYLOADS.loop.label}</button>
-      <button class="g-md${pm==='think'?' act':''}" data-m="think">${PAYLOADS.think.label}</button>
-      <button class="g-md${pm==='roadmap'?' act':''}" data-m="roadmap">${PAYLOADS.roadmap.label}</button>
-    </div>
-    <div class="g-hint">${PAYLOADS[pm].hint}</div>
-    <div class="g-posture-wrap">
-      <div class="g-posture-lbl">Thinking posture <button class="g-posture-q" id="g-posture-help" title="What do these mean?">?</button></div>
-      <div class="g-postures">
-        <button class="g-pst${L.posture==='standard'?' act':''}" data-pst="standard">${POSTURES.standard.label}</button>
-        <button class="g-pst${L.posture==='evolving'?' act':''}" data-pst="evolving">${POSTURES.evolving.label}</button>
-        <button class="g-pst${L.posture==='extended'?' act':''}" data-pst="extended">${POSTURES.extended.label}</button>
-      </div>
-      <div class="g-posture-hint">${_esc((POSTURES[L.posture]||POSTURES.standard).desc)}</div>
-    </div>
-    ${L.state==='LIMIT' ? `<div class="g-limit"><div class="g-limit-h">⏸ Drift checkpoint — ${L.maxRounds} auto-continues reached</div><div class="g-limit-b">A grounding pause so the run can't wander off-task unattended. What next?</div><div class="g-limit-btns"><button class="g-btn go pulse" id="g-limit-go">▶ Continue ${L.limitStep} more</button><button class="g-btn rg" id="g-limit-reground" title="Re-anchor the AI to the task it started on, then continue">⊕ Reground</button><button class="g-btn st" id="g-limit-wait" title="Pause and wait for your instructions">✋ Stop &amp; wait</button></div></div>` : ''}
+    ${firstRun ? `<div class="g-firstrun"><b>👻 Quick start</b><br>1. Type your task in the chat box<br>2. Press ▶ — Ghost auto-continues until done<br>3. Walk away ☕<br><button class="g-btn-sm" id="g-onb-done">Got it</button></div>` : ''}
+    ${pLabel?`<div class="g-hint" style="border-left-color:#6d28d9">♙ ${_esc(pLabel)}${GHOST.persona.perTask?' · per-task':''}${GHOST.persona.finalReview?' · final review':''} <a href="#" class="g-plink" id="g-goto-personas">edit</a></div>`:''}
+    ${L.state==='LIMIT' ? `<div class="g-limit"><div class="g-limit-h">⏸ Drift checkpoint — ${L.maxRounds} auto-continues reached</div><div class="g-limit-b">A grounding pause so the run cannot wander off-task unattended.</div><div class="g-limit-btns"><button class="g-btn go pulse" id="g-limit-go">▶ Continue ${L.limitStep} more</button><button class="g-btn rg" id="g-limit-reground">⊕ Reground</button><button class="g-btn st" id="g-limit-wait">✋ Stop &amp; wait</button></div></div>` : ''}
+    <div class="g-mod g-mod-transport">
+      <div class="g-mod-h"><span class="g-mod-i">🎛</span>Transport<span class="g-mod-x" style="color:${statColor()}">${statLabel()}</span></div>
     <div class="g-btns">
-      <button class="g-btn go${L.state==='LIMIT'?' pulse':''}" id="g-play" title="${L.state==='LIMIT'?`Continue ${L.limitStep} more`:'Start / Resume (Alt+P)'}">▶</button>
-      <button class="g-btn" id="g-pause" title="Pause (Alt+P)">⏸</button>
-      <button class="g-btn st" id="g-stop" title="Stop & Reset (Alt+S)">■</button>
+      <button class="g-btn go${L.state==='LIMIT'?' pulse':''}" id="g-play" title="Start / Resume (Alt+P)">▶</button>
+      <button class="g-btn${idle?' g-dim':''}" id="g-pause" title="Pause auto-continue (Alt+P)">⏸</button>
+      <button class="g-btn${idle?' g-dim':''}" id="g-reground" title="Re-anchor AI to original task — use when you see drift">⊕</button>
     </div>
+    </div>
+    <div class="g-mod g-mod-prog">
+      <div class="g-mod-h"><span class="g-mod-i">📊</span>Progress<span class="g-mod-x">${p?pct+'%':'—'}</span></div>
     <div class="g-prog">
       <div class="g-trk"><div class="g-fill" style="width:${pct}%"></div></div>
       <div class="g-plbl">
@@ -2731,21 +3708,45 @@ function renderRunTab() {
       ${(L.state==='RUNNING'||L.state==='PAUSED'||L.state==='LIMIT') ? (()=>{
         const left = Math.max(0, L.maxRounds - L.round);
         const lowpct = L.maxRounds ? (left / L.maxRounds) * 100 : 100;
-        const warn = left <= 5;
-        return `<div class="g-safety${warn?' warn':''}" title="Safety check: Ghost pauses after ${L.maxRounds} auto-continues so it can't drift or invent steps unattended. Not your task length — just a drift guard.">
+        const warn = L.driftEnabled && left <= 5;
+        const off = !L.driftEnabled;
+        return `<div class="g-safety${warn?' warn':''}${off?' off':''}" title="${off?'Drift guard OFF — loop runs without a cap.':'Drift guard: auto-pauses after this many continues.'}">
           <div class="g-safety-row">
+            <div class="g-tog${L.driftEnabled?' on':''}" id="g-drift-tog"></div>
             <span class="g-safety-lbl">drift guard</span>
-            <span class="g-safety-num"><b>${left}</b> left of ${L.maxRounds}</span>
-            <button class="g-safety-rst" id="g-cnt-reset" title="Reset this counter back to ${L.maxRounds} (does not touch your chat or the page)">↻</button>
+            <span class="g-safety-num">${off?'OFF':'<b>'+left+'</b> left'}</span>
+            <input type="number" class="g-safety-edit" id="g-drift-max" value="${L.maxRounds}" min="1" max="999">
+            <button class="g-safety-rst" id="g-cnt-reset">↻</button>
           </div>
-          <div class="g-safety-trk"><div class="g-safety-fill" style="width:${lowpct}%"></div></div>
+          ${!off?`<div class="g-safety-trk"><div class="g-safety-fill" style="width:${lowpct}%"></div></div>`:''}
         </div>`;
       })() : ''}
     </div>
-    <div class="g-stat" style="color:${statColor()}">${statLabel()}</div>
+    </div>
+    <div class="g-detect" style="font-size:8.5px;color:#555;margin-top:2px">● ${PLAT?PLAT.label:'—'} · ${PAYLOADS[pm].label} · ${(POSTURES[L.posture]||POSTURES.standard).label}${L.state!=='IDLE'?' · R'+L.round:''}</div>
     ${GHOST.report ? `<div class="g-report"><div class="g-report-h">⚠ Trouble report ready <span class="g-report-k">${GHOST.report.kind}</span></div><div class="g-report-b">${(GHOST.report.detail||'').slice(0,120)}</div><div class="g-report-btns"><button class="g-btn-sm" id="g-rep-copy">📋 Copy</button><button class="g-btn-sm" id="g-rep-issue">↗ Open issue</button><button class="g-btn-sm" id="g-rep-x" style="background:#18191c">✕</button></div></div>` : ''}
+    <button class="g-adv" id="run-adv">${runAdv?'Advanced ▴':'Advanced ▾'}</button>
+    ${runAdv ? `
+    <div class="g-mod g-mod-adv">
+      <div class="g-mod-h"><span class="g-mod-i">🧭</span>Strategy<span class="g-mod-x">${PAYLOADS[pm].label}</span></div>
+    <div class="g-row"><label>Strategy</label><select id="g-strategy" style="width:120px"><option value="loop"${pm==='loop'?' selected':''}>Step by step</option><option value="think"${pm==='think'?' selected':''}>Plan first</option><option value="roadmap"${pm==='roadmap'?' selected':''}>Autopilot</option></select></div>
+    <div class="g-hint">${PAYLOADS[pm].hint}</div>
+    </div>
+    <div class="g-mod g-mod-adv">
+      <div class="g-mod-h"><span class="g-mod-i">🧠</span>Thinking<span class="g-mod-x">${(POSTURES[L.posture]||POSTURES.standard).label}</span></div>
+    <div class="g-posture-wrap">
+      <div class="g-posture-lbl">Thinking <button class="g-posture-q" id="g-posture-help">?</button></div>
+      <div class="g-postures">
+        <button class="g-pst${L.posture==='standard'?' act':''}" data-pst="standard">${POSTURES.standard.label}</button>
+        <button class="g-pst${L.posture==='evolving'?' act':''}" data-pst="evolving">${POSTURES.evolving.label}</button>
+        <button class="g-pst${L.posture==='extended'?' act':''}" data-pst="extended">${POSTURES.extended.label}</button>
+      </div>
+    </div>
+    </div>
     <div class="g-peek-btn" id="g-peek-btn">${peekOpen?'▾ Hide prompt':'▸ What gets injected'}</div>
     <div class="g-peek${peekOpen?' open':''}" id="g-peek">${PAYLOADS[pm].preview}</div>
+    <button class="g-btn st" id="g-stop" style="width:100%;font-size:9px;padding:5px;margin-top:5px">✕ End &amp; reset</button>
+    ` : ''}
     <div class="g-shortcuts">v${VER} · Alt+P toggle · Alt+S stop</div>`;
 }
 
@@ -2785,6 +3786,7 @@ function renderFlowTab() {
         ${GHOST.workflow.pauseBetween ? '<br><br>⏸ <b>Pause between is ON</b> — Ghost stops after each stage so you can review or switch models, then press ▶ to continue.' : ''}
       </div>
       <button class="g-btn go g-wf-start${running?' g-dim':''}" id="wf-start"${running?' disabled':''}>▶ Start workflow</button>
+      ${running||GHOST.workflow.active ? `<div class="g-btns" style="margin-top:4px"><button class="g-btn" id="wf-do-pause" title="Pause workflow">⏸</button><button class="g-btn st" id="wf-do-stop" title="Stop & reset workflow">✕ End</button></div>` : ''}
       <div class="g-row" style="margin-top:8px"><label>Pause between stages</label><div class="g-tog${GHOST.workflow.pauseBetween?' on':''}" id="wf-pause"></div></div>
       <div class="g-wf-progress">Stage <b>${wf.stages.length?(GHOST.workflow.stageIndex+1):'—'}</b> of ${wf.stages.length} ${GHOST.workflow.active?'· running':''}</div>
       <div class="g-div"></div>${stages}
@@ -2803,10 +3805,11 @@ const HELP_SECTIONS = {
     <b>The 30-second version:</b><br>1. Type your task in the chat box<br>2. Press the big ▶<br>3. Walk away ☕<br><br>
     <b>How does it know when to stop?</b><br>Ghost teaches the AI two signals: <code>[[GITL::PROCEED]]</code> = "more to do", <code>[[GITL::HALT]]</code> = "finished". Ghost reads them and acts.` },
   run: { label: 'Run', html: `
-    <b>The Run tab</b> is the classic loop.<br><br>
-    <b>Three modes:</b><br>· <b>Loop</b> — AI works in batches, Ghost continues each one<br>· <b>Think First</b> — AI plans before working, then batches<br>· <b>Roadmap</b> — AI researches, writes its own plan, Ghost runs every step (see Auto)<br><br>
-    <b>Buttons:</b> ▶ start/resume · ⏸ pause · ⏹ stop &amp; reset<br><br>
-    <b>Q: It stopped and shows "drift checkpoint"?</b><br>That's the drift guard (default 20 auto-continues) catching a long run — <i>not</i> an error. It's a grounding pause so an unattended run can't wander off-task. Three choices:<br>· <b>▶ Continue</b> — run 20 more (asks again each 20)<br>· <b>⊕ Reground</b> — re-anchor the AI to the task it started on, then continue<br>· <b>✋ Stop &amp; wait</b> — pause for your instructions<br>Raise the default in Setup → Max rounds, or tap ↻ on the drift-guard bar to reset the count anytime.` },
+    <b>The Run tab</b> is command center.<br><br>
+    <b>Strategy dropdown:</b><br>· <b>Step by step</b> — AI works in batches, Ghost continues each one<br>· <b>Plan first</b> — AI plans before working, then batches<br>· <b>Autopilot</b> — AI researches, writes its own plan, Ghost runs every step<br><br>
+    <b>Buttons:</b> ▶ start/resume · ⏸ pause · ⊕ reground (re-anchor AI to the original task if you see drift). Full stop is in Advanced ▾.<br><br>
+    <b>Personas line:</b> shows your active persona or committee. Tap "edit" to jump to the Personas tab.<br><br>
+    <b>Q: It stopped and shows "drift checkpoint"?</b><br>That's the drift guard catching a long run. It's a grounding pause so an unattended run cannot wander off-task. Three choices:<br>· <b>▶ Continue</b> — run more<br>· <b>⊕ Reground</b> — re-anchor the AI to the task it started on<br>· <b>✋ Stop &amp; wait</b> — pause for your instructions<br>You can edit the cap inline, toggle the guard off, or tap ↻ to reset.` },
   auto: { label: 'Auto', html: `
     <b>The Auto tab</b> = fire &amp; forget.<br><br>
     <b>Roadmap</b> (AI plans): pick Roadmap on Run, press ▶. The AI studies your task, writes a numbered plan, and Ghost executes every step + a final synthesis. Watch steps get ✓ here.<br><br>
@@ -2817,24 +3820,29 @@ const HELP_SECTIONS = {
     <b>To run one:</b><br>1. Pick a workflow from the dropdown<br>2. Type your task in the chat box<br>3. Press <b>▶ Start workflow</b><br>Ghost runs every stage in order, advancing each time the AI HALTs.<br><br>
     <b>INSERT button</b> (the small vertical tab on each stage): drops just that one stage's prompt into the chat box, so you can run a single stage by hand instead of the whole sequence.<br><br>
     <b>Pause between stages:</b> OFF = Ghost runs start-to-finish. ON = Ghost stops after each stage so you can review — or switch the model (that's how <b>Lens Relay</b> works: swap model at each pause, press ▶ to continue).` },
-  roles: { label: 'Roles', html: `
-    <b>The Roles tab</b> injects a persona into your first prompt — Red Team attacks the work, Round Table simulates a committee, and so on.<br><br>
-    <b>On Perplexity</b>, Round Table automatically becomes a REAL round table: it expects you to switch models between turns, and each model must give its own independent assessment, in a code block, naming who goes next.` },
+  roles: { label: 'Personas', html: `
+    <b>The Personas tab</b> shapes how the AI approaches your task.<br><br>
+    <b>Basic:</b> pick a persona from the dropdown — Red Team attacks the work, Researcher digs deep, Devil's Advocate challenges every claim. The persona framing is injected into your first prompt.<br><br>
+    <b>Committee mode</b> (toggle at top): select multiple personas. The AI simulates all perspectives on every response, then synthesizes a consensus with disagreements preserved.<br><br>
+    <b>Per-task toggle:</b> re-inject the committee framing on every step, not just the first.<br>
+    <b>Final review toggle:</b> after all work completes, the committee does one final review pass before halting.<br><br>
+    <b>On Perplexity</b>, Round Table becomes a REAL round table: switch models between turns, each model gives independent assessment naming who goes next.` },
   export: { label: 'Export', html: `
     <b>Three buttons, three jobs:</b><br><br>
     <b>⬇ Export</b> — the full record. The whole conversation as a file (with 💭 thinking logs). For archiving and reading.<br><br>
     <b>🤝 Handoff</b> — moving to another model? Ghost asks THIS AI to write a structured briefing in-chat (mission, decisions, failures, next steps). Paste it into the new model. The AI's own summary beats a raw transcript — decisions don't get buried.<br><br>
-    <b>🛟 Rescue</b> — the chat is full, stuck, or won't respond, so you can't ask it anything. Ghost scrapes the state + last 10 messages verbatim + resumption instructions into a file. Paste into a fresh chat and keep going.<br><br>
-    <i>Working chat → Handoff. Dead chat → Rescue. Records → Export.</i>` },
+    <b>🧷 Backup Handoff</b> — the chat is full, stuck, or won't respond, so it can't write its own briefing (that's what Handoff normally does). Ghost writes a smaller one instead: state + last 10 messages verbatim + resumption instructions. Deliberately lighter than a full export — just enough to resume elsewhere.<br><br>
+    <i>Working chat → Handoff (AI writes it, fullest briefing). Dead chat → Backup Handoff (Ghost writes it, lighter — Handoff's calmer sibling, not a separate emergency). Complete record → Export (fullest of all four, not for resuming — for keeping).</i>` },
   setup: { label: 'Setup', html: `
-    <b>The Setup tab:</b><br>· <b>Max rounds</b> — drift-guard cap on auto-continues<br>· <b>Notify</b> — desktop alert when done (great with ☕)<br>· <b>Position</b> — corners, bottom bar, ▐ <b>Dock</b> (slim right-edge tab that never covers the chat), or ☰ <b>Gold menu</b> (the same slim tab on the left edge, opposite most sites' own menu, styled gold)<br><br>
+    <b>The Setup tab:</b><br>· <b>Max rounds</b> — drift-guard cap on auto-continues<br>· <b>Notify</b> — desktop alert when done (great with ☕)<br>· <b>Position</b> — corners, bottom bar, ▐ <b>Dock</b> (slim right-edge tab that never covers the chat), or ☰ <b>Gold menu</b> (the same slim tab on the left edge, opposite most sites' own menu, styled gold)<br>· <b>Unattended</b> — by default Ghost stops sending the moment the tab loses focus (a guard against burning tokens unwatched). Turn it on to keep a run going in a background tab; it also moves the loop onto a Web Worker timer, because browsers throttle background <code>setInterval</code> to about once a minute. The tab must remain open — closing the browser still ends the run. Drift guard and round limits still apply.<br>
+· <b>Skin</b> — 13 presets (Classic, Aurora, Glass, Metal, Neon, Clay, Liquid, OLED, Paper, HUD, Nova, Ion, Flow) or Custom. Swatches or the slider tint the accent family on any of them. (import a .gitl.json skin file). Skins are pure style tokens: they can never add, remove, or change buttons and features, and old skins keep working on new GITL versions<br>· <b>Accent</b> — hue slider to tint the interface any color you want<br><br>
     <b>🔄 Re-detect (top of panel):</b> if Ghost says it can't find the chat box — common after switching between the browser and the app, or between tabs — tap 🔄. It re-finds the input without reloading the page, so you don't have to hop between chats to wake it up.<br><br>
     <b>Advanced ▾</b> hides the power tools: custom signal words, per-site selector overrides (Custom sites), and <b>Diagnostics → Probe</b>, which live-tests Ghost's connection to the page — your first stop when a platform misbehaves.` },
   posture: { label: 'Posture', html: `
     <b>Thinking posture = how much room the AI has to grow its own plan.</b> You pick it up front, like a reasoning dial — Ghost never guesses. It works with any mode (Loop / Think / Roadmap).<br><br>
-    <b>Standard</b> — locked. The AI does exactly the steps it declared, nothing more. Most predictable; best when you know the scope.<br><br>
-    <b>Evolving</b> (a.k.a. <i>adaptive</i>) — the AI may add steps <i>while working</i>, but only when it hits a real blocker or a gap that would otherwise make it fail the goal — and it must justify each addition in one line. It can't wander into unrelated topics, and it stays under the drift-guard ceiling.<br><br>
-    <b>Extended</b> (a.k.a. <i>review</i>) — the AI runs the plan locked, then does <i>one</i> gap-check at the end: what's missing or unanswered against the original goal. It fills only genuinely valuable holes, then stops. If nothing's missing, it says so and halts.<br><br>
+    <b>Locked</b> (formerly Standard) — The AI does exactly the steps it declared, nothing more. Most predictable; best when you know the scope.<br><br>
+    <b>Adaptive</b> (formerly Evolving) — the plan can <i>grow</i>: the AI may add steps <i>while working</i>, but only when it hits a real blocker or a gap that would otherwise make it fail the goal — and it must justify each addition in one line. It can't wander into unrelated topics, and it stays under the drift-guard ceiling.<br><br>
+    <b>Audit</b> (formerly Extended) (a.k.a. <i>review</i>) — the AI runs the plan locked, then does <i>one</i> gap-check at the end: what's missing or unanswered against the original goal. It fills only genuinely valuable holes, then stops. If nothing's missing, it says so and halts.<br><br>
     All three keep the drift guard as the hard ceiling — if the AI hits it, it stops and reports the biggest unresolved gap instead of padding. <span style="color:#5a5d68">(Wording based on current best-practice research: OpenAI/Anthropic planning guidance, ReAct/Reflexion, Self-Refine, and agent guardrail patterns.)</span>` },
   workshop: { label: 'Workshop', html: `
     <b>Make Ghost yours — and share it.</b><br><br>
@@ -2892,24 +3900,51 @@ function renderAutoTab() {
 }
 
 function renderPersonasTab() {
-  const items = Object.entries(allPersonas()).map(([k,v]) =>
-    `<button class="g-persona-btn${GHOST.persona.selected===k?' act':''}" data-p="${_esc(k)}">
-       <span class="plbl">${v.custom?'<span class="g-cust-badge">★</span> ':''}${_esc(v.label)}${v.custom?`<span class="g-del" data-del-p="${_esc(k)}" title="Delete this custom persona">✕</span>`:''}</span>
-       <div class="pdesc">${_esc(v.inject||'No persona framing.')}</div>
-     </button>`
-  ).join('');
+  const sel = GHOST.persona.selected || ['none'];
+  const comm = GHOST.persona.committee;
   const creating = GHOST.ui.wsNewPersona;
-  const form = creating ? `
+  const allP = allPersonas();
+  const activeP = sel.filter(s=>s&&s!=='none');
+
+  // Basic: single persona selector with preview
+  const opts = Object.entries(allP).map(([k,v]) => `<option value="${_esc(k)}"${!comm&&sel.includes(k)&&k!=='none'?' selected':''}>${v.custom?'★ ':''}${_esc(v.label)}</option>`).join('');
+  const curKey = !comm && activeP.length===1 ? activeP[0] : null;
+  const curP = curKey ? allP[curKey] : null;
+
+  // Committee: multi-select rows
+  const committeeRows = comm ? activeP.map((k,i) => {
+    const p = allP[k];
+    const rowOpts = Object.entries(allP).filter(([id])=>id!=='none').map(([id,v]) => `<option value="${_esc(id)}"${id===k?' selected':''}>${v.custom?'★ ':''}${_esc(v.label)}</option>`).join('');
+    return `<div class="g-qrow"><select class="g-qin g-cm-sel" data-ci="${i}" style="flex:1">${rowOpts}</select><button class="g-qdel g-cm-del" data-ci="${i}">✕</button></div><div class="g-hint" style="margin-top:-2px;margin-bottom:5px;font-size:8.5px">${p?_esc(p.inject.slice(0,80))+(p.inject.length>80?'…':''):'Unknown persona'}</div>`;
+  }).join('') : '';
+
+  return `
+    <div class="g-row"><label>Committee</label><div class="g-tog${comm?' on':''}" id="p-comm-tog" title="Toggle committee mode — select multiple personas"></div></div>
+    ${!comm ? `
+      <div class="g-row"><label>Persona</label><select id="p-single" style="width:130px"><option value="none"${activeP.length===0?' selected':''}>None</option>${opts}</select></div>
+      ${curP ? `<div class="g-hint" style="line-height:1.6"><b>${_esc(curP.label)}</b>${curP.custom?' <span class="g-cust-badge">★ custom</span>':''}<br>${_esc(curP.inject.slice(0,200))}${curP.inject.length>200?'…':''}</div>` : '<div class="g-hint">No persona active — the AI uses its default behavior.</div>'}
+      <button class="g-exp-btn" id="p-run" style="margin-top:4px">▶ Run with${curP?' '+_esc(curP.label):' persona'}</button>
+    ` : `
+      <div style="font-size:9px;color:#777;font-weight:700;margin:4px 0">COMMITTEE MEMBERS (${activeP.length})</div>
+      ${committeeRows}
+      <button class="g-btn-sm" id="p-cm-add" style="width:100%;margin-top:4px">＋ Add member</button>
+      <div class="g-div"></div>
+      <div class="g-row"><label>Per-task</label><div class="g-tog${GHOST.persona.perTask?' on':''}" id="p-pertask" title="Apply committee perspective to every step, not just the first"></div></div>
+      <div class="g-row"><label>Final review</label><div class="g-tog${GHOST.persona.finalReview?' on':''}" id="p-review" title="Committee conducts a final review after all work is complete"></div></div>
+      <div class="g-hint">Per-task = each step runs with the committee framing. Final review = after the last step, the committee reviews and synthesizes.</div>
+      <button class="g-exp-btn" id="p-run" style="margin-top:4px">▶ Run with committee (${activeP.length})</button>
+    `}
+    <div class="g-div"></div>
+    ${creating ? `
     <div class="g-ws-form">
       <input class="g-ws-in" id="ws-p-label" placeholder="Persona name (e.g. Legal Reviewer)" maxlength="40">
       <textarea class="g-ws-ta" id="ws-p-inject" placeholder="Persona framing — 'Adopt the persona of…'" rows="3" maxlength="4000"></textarea>
       <div class="g-ws-form-btns"><button class="g-btn-sm" id="ws-p-save">✓ Save persona</button><button class="g-btn-sm" id="ws-p-cancel" style="background:#18191c">Cancel</button></div>
-    </div>` : `<button class="g-exp-btn" id="ws-p-new" style="margin-top:5px">＋ Create custom persona</button>`;
-  return items + form + `
+    </div>` : `<button class="g-exp-btn" id="ws-p-new" style="margin-top:2px">＋ Create custom persona</button>`}
     <div class="g-ws-bar">
-      <button class="g-ws-btn" id="ws-import" title="Import a .gitl.json pack of personas & workflows">⬆ Import</button>
-      <button class="g-ws-btn" id="ws-export" title="Export your custom personas & workflows to a shareable file">⬇ Export</button>
-      <button class="g-ws-btn" id="ws-submit" title="Share your pack with the community">🌐 Share</button>
+      <button class="g-ws-btn" id="ws-import">⬆ Import</button>
+      <button class="g-ws-btn" id="ws-export">⬇ Export</button>
+      <button class="g-ws-btn" id="ws-submit">🌐 Share</button>
     </div>`;
 }
 
@@ -2919,11 +3954,12 @@ function renderExportTab() {
   return `
     <div class="g-row"><label>Format</label><select id="exp-fmt"><option value="markdown"${GHOST.export.format==='markdown'?' selected':''}>Markdown</option><option value="json"${GHOST.export.format==='json'?' selected':''}>JSON</option></select></div>
     <div class="g-row"><label>💭 Thinking logs</label><div class="g-tog${GHOST.export.thinking?' on':''}" id="exp-think"></div></div>
-    <button class="g-exp-btn" id="g-export">⬇ Export conversation</button>
-    <button class="g-exp-btn" id="g-capsule" style="margin-top:5px">💊 Capsule v2 — resumable JSON</button>
-    <button class="g-exp-btn" id="g-handoff" style="margin-top:5px">🤝 Handoff — AI writes the baton</button>
-    <button class="g-exp-btn" id="g-rescue" style="margin-top:5px;background:#18191c;border-color:#2e2f35;color:#ccc">🛟 Rescue file (chat stuck/full)</button>
-    <div class="g-hint" style="margin-top:4px"><b>Export</b> = full record. <b>Handoff</b> = the AI writes a briefing in-chat for the next model. <b>Rescue</b> = chat won't respond anymore — scrape the tail + instructions into a file for a fresh chat.</div>
+    <div class="g-xlist">
+      <div class="g-xrow g-xrow-accent" id="g-export"><span class="g-xicon">⬇</span><div class="g-xtext"><b>Export</b><span>Full transcript, markdown or JSON. The complete record — for keeping.</span></div></div>
+      <div class="g-xrow g-xrow-muted" id="g-capsule"><span class="g-xicon">💊</span><div class="g-xtext"><b>Capsule v2</b><span>Resumable JSON with a resume token — for feeding back into an API or tool.</span></div></div>
+      <div class="g-xrow g-xrow-ok" id="g-handoff"><span class="g-xicon">🤝</span><div class="g-xtext"><b>Handoff</b><span>Chat still responds: asks the AI to write its own briefing for the next chat.</span></div></div>
+      <div class="g-xrow g-xrow-warn" id="g-rescue"><span class="g-xicon">🧷</span><div class="g-xtext"><b>Backup Handoff</b><span>Chat is dead: Ghost writes a lighter one itself — state + last 10 messages, enough to resume elsewhere.</span></div></div>
+    </div>
     <button class="g-adv" id="exp-adv">${adv?'Advanced ▴':'Advanced ▾'}</button>
     ${adv ? `
     <div class="g-row"><label>Filter</label><select id="exp-flt"><option value="all"${GHOST.export.filter==='all'?' selected':''}>All</option><option value="user"${GHOST.export.filter==='user'?' selected':''}>User</option><option value="assistant"${GHOST.export.filter==='assistant'?' selected':''}>Assistant</option><option value="code"${GHOST.export.filter==='code'?' selected':''}>Code blocks</option></select></div>
@@ -2950,6 +3986,12 @@ function renderSettingsTab() {
       ).join('')}</div>
     </div>
     <div class="g-row"><label>❓ Quick start</label><button class="g-btn-sm" id="cfg-qs" style="margin-top:0">Show</button></div>
+    <div class="g-div"></div>
+    <div class="g-row"><label>🌙 Unattended</label><div class="g-tog${GHOST.ui.unattended?' on':''}" id="cfg-unattended"></div></div>
+    <div class="g-hint" style="margin-top:-2px;margin-bottom:5px">Keeps running when the tab is in the background. The tab must stay <b>open</b> — this does not move the run to a server. Off by default: it sends prompts while you're not looking.</div>
+    <div class="g-row"><label>🎨 Skin</label><select id="cfg-skin" style="width:100px">${[...Object.keys(SKIN_PRESETS),'custom'].map(k=>`<option value="${k}"${GHOST.ui.skinTheme===k?' selected':''}>${k==='custom'?'Custom…':SKIN_PRESETS[k].name}</option>`).join('')}</select><button class="g-btn-sm" id="cfg-skin-imp" title="Import a .gitl.json skin" style="margin-top:0">⬆</button><button class="g-btn-sm" id="cfg-skin-exp" title="Export active skin — edit the file, re-import: that's the whole modding loop" style="margin-top:0">⬇</button></div>
+    <div class="g-row"><label>🌈 Accent</label><input type="range" id="cfg-hue" title="Tint accent · double-click resets to the skin&#39;s own hue" min="0" max="360" value="${Number.isFinite(GHOST.ui.accentHue)?GHOST.ui.accentHue:SKIN.baseHue()}" style="width:80px;accent-color:hsl(${Number.isFinite(GHOST.ui.accentHue)?GHOST.ui.accentHue:SKIN.baseHue()} 100% 60%)"><span style="width:14px;height:14px;border-radius:50%;background:hsl(${Number.isFinite(GHOST.ui.accentHue)?GHOST.ui.accentHue:SKIN.baseHue()} 100% 60%);display:inline-block;margin-left:5px;border:1px solid #2e2f35;flex-shrink:0"></span></div>
+    <div class="g-swatches">${[350,265,220,185,145,40].map(h=>`<button class="g-swatch" data-hue="${h}" title="Set accent" style="background:hsl(${h} 85% 58%)"></button>`).join('')}</div>
     <button class="g-adv" id="cfg-adv">${adv?'Advanced ▴':'Advanced ▾'}</button>
     ${adv ? `
     <div class="g-row"><label>Signal window</label><input type="number" id="cfg-win" min="200" max="1200" step="100" value="${GHOST.signals.windowSize}"></div>
@@ -3011,6 +4053,7 @@ function renderReportBadge() {
 }
 
 function render() {
+  try { panel.dataset.run = (GHOST.loop.state === 'RUNNING') ? '1' : '0'; panel.dataset.explain = GHOST.ui.explain ? '1' : '0'; } catch(_) {}
   const L = GHOST.loop, tab = GHOST.ui.tab, col = GHOST.ui.collapsed;
   const isDock = GHOST.ui.position==='dock' || GHOST.ui.position==='dock-left';
   panel.className = [col?'collapsed':'', GHOST.ui.position==='bottom-bar'?'pos-bb':'', GHOST.ui.position==='dock'?'pos-dock':'', GHOST.ui.position==='dock-left'?'pos-dock pos-dock-left':''].filter(Boolean).join(' ');
@@ -3018,9 +4061,24 @@ function render() {
   const ql = L.state==='RUNNING'?'Running…':L.state==='LIMIT'?`▶ ${L.maxRounds} reached — tap for ${L.limitStep} more`:L.state==='PAUSED'?'Paused':L.state==='COMPLETE'?'Done':'Idle';
   const qIcon = L.state==='RUNNING'?'⏸':'▶';
   const qCls  = L.state==='RUNNING'?'pause':L.state==='LIMIT'?'play limit':'play';
+  // Compact dock status: step/round + drift guard remaining (editable)
+  const dockStat = (()=>{
+    if (L.state==='IDLE'||L.state==='COMPLETE') return '';
+    const p = L.lastProgress;
+    const pctv = (p && p.total) ? Math.round((p.step / p.total) * 100) : null;
+    const bar = pctv !== null
+      ? `<span class="g-dk-bar" title="Step ${p.step} of ${p.total}"><i style="width:${pctv}%"></i></span>`
+      : '';
+    const line1 = p ? `${p.step}/${p.total}` : (L.round ? `round ${L.round}` : '');
+    const left = L.driftEnabled ? Math.max(0, L.maxRounds - L.round) : null;
+    const line2 = left !== null
+      ? `<span class="g-dk-drift" title="Drift guard: ${left} of ${L.maxRounds} continues left before Ghost pauses to check in. Tap the number to change the limit, ↻ resets the counter."><span class="g-dk-cap">${left} left</span><input type="number" class="g-dk-edit" id="g-dk-max" value="${L.maxRounds}" min="1" max="999"><button class="g-dk-rst" id="g-dk-reset">↻</button></span>`
+      : '';
+    return [bar, line1, line2].filter(Boolean).join('');
+  })();
   panel.innerHTML = `
     <div class="g-hdr" id="g-drag">
-      <span class="g-logo">${col && GHOST.ui.position==='dock-left' ? '☰ Ghost' : '👻 Ghost'}<span class="g-dot ${dotClass()}"></span></span>
+      <span class="g-logo">${col && GHOST.ui.position==='dock-left' ? '☰ Ghost' : '<span class="g-ghost">👻</span> Ghost'}<span class="g-dot ${dotClass()}"></span></span>
       <span style="display:flex;align-items:center;gap:5px">
         <span class="g-plat">${(typeof platformHealth==='function'?platformHealth().badge:'') + ' ' + PLAT.label}</span>
         <button class="g-minbtn" id="g-redetect" title="Re-detect the chat box — fixes 'can't find input' after switching browser/app or tabs (no page reload)">🔄</button>
@@ -3031,6 +4089,7 @@ function render() {
     <div class="g-coll-row">
       <button class="g-qbtn ${qCls}" id="g-quick">${qIcon}</button>
       <span class="g-qstat" style="color:${qc}">${ql}</span>
+      ${dockStat?`<span class="g-dock-stat">${dockStat}</span>`:''}
     </div>
     <div class="g-body">
       <div class="g-proj">
@@ -3041,11 +4100,12 @@ function render() {
         <button class="g-tab${tab==='run'?' act':''}" data-t="run" title="Standard continue loop">Run</button>
         <button class="g-tab${tab==='auto'?' act':''}" data-t="auto" title="Roadmap autopilot & prompt queue">Auto</button>
         <button class="g-tab${tab==='flow'?' act':''}" data-t="flow" title="Multi-stage workflows">Flow</button>
-        <button class="g-tab${tab==='personas'?' act':''}" data-t="personas" title="Personas">Roles</button>
+        <button class="g-tab${tab==='personas'?' act':''}" data-t="personas" title="Personas & committee">Personas</button>
         <button class="g-tab${tab==='export'?' act':''}" data-t="export" title="Export & handoff">Export</button>
         <button class="g-tab${tab==='settings'?' act':''}" data-t="settings" title="Settings">Setup</button>
       </div>
       <div id="g-tc">
+        <button class="g-tabhelp" id="g-explain-tog" title="Explain mode — tap ⓘ, then tap any control to learn what it does" style="right:20px">ⓘ</button>
         ${TAB_HELP[tab] && tab!=='info' ? `<button class="g-tabhelp" id="g-tabhelp" data-h="${TAB_HELP[tab]}" title="Help for this tab">?</button>` : ''}
         ${tab==='run'?renderRunTab():''}${tab==='auto'?renderAutoTab():''}${tab==='info'?renderInfoTab():''}${tab==='flow'?renderFlowTab():''}
         ${tab==='personas'?renderPersonasTab():''}${tab==='export'?renderExportTab():''}
@@ -3081,11 +4141,18 @@ function bindEvents() {
   $$('.g-tab').forEach(b => b.addEventListener('click', () => { GHOST.ui.tab=b.dataset.t; render(); }));
   $('#g-tabhelp')?.addEventListener('click', function(){ GHOST.ui.prevTab = GHOST.ui.tab; GHOST.ui.helpSec = this.dataset.h; GHOST.ui.tab = 'info'; render(); });
 
-  // Run tab
+  // Run tab — strategy dropdown
   $$('.g-md').forEach(b => b.addEventListener('click', () => {
     if (GHOST.loop.state==='RUNNING') return;
     GHOST.loop.payloadMode=b.dataset.m; GHOST.loop.needsPayload=true; _save('payloadMode',GHOST.loop.payloadMode); render();
   }));
+  $('#g-strategy')?.addEventListener('change', e => {
+    if (GHOST.loop.state==='RUNNING') return;
+    GHOST.loop.payloadMode=e.target.value; GHOST.loop.needsPayload=true; _save('payloadMode',GHOST.loop.payloadMode); render();
+  });
+  $('#run-adv')?.addEventListener('click', () => { GHOST.ui.runAdv=!GHOST.ui.runAdv; render(); });
+  $('#g-goto-personas')?.addEventListener('click', e => { e.preventDefault(); GHOST.ui.tab='personas'; render(); });
+  $('#g-reground')?.addEventListener('click', () => { if (GHOST.loop.state==='RUNNING'||GHOST.loop.state==='PAUSED') regroundLoop(); });
   $$('.g-pst').forEach(b => b.addEventListener('click', () => {
     if (GHOST.loop.state==='RUNNING') return;
     GHOST.loop.posture=b.dataset.pst; _save('posture',GHOST.loop.posture); render();
@@ -3095,6 +4162,12 @@ function bindEvents() {
   $('#g-limit-go')?.addEventListener('click', extendLimit);
   $('#g-limit-reground')?.addEventListener('click', regroundLoop);
   $('#g-limit-wait')?.addEventListener('click', () => enginePause('✋ Stopped at drift checkpoint — ▶ to resume'));
+  $('#g-drift-tog')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.loop.driftEnabled=this.classList.contains('on'); _save('driftEnabled',GHOST.loop.driftEnabled); render(); });
+  $('#g-drift-max')?.addEventListener('change', e => { const v=parseInt(e.target.value,10); if(v>0&&v<=999){GHOST.loop.maxRounds=v; _save('maxRounds',v); render();} });
+  $('#g-drift-max')?.addEventListener('click', e => e.stopPropagation());
+  $('#g-dk-max')?.addEventListener('change', e => { const v=parseInt(e.target.value,10); if(v>0&&v<=999){GHOST.loop.maxRounds=v; _save('maxRounds',v); render();} });
+  $('#g-dk-max')?.addEventListener('click', e => e.stopPropagation());
+  $('#g-dk-reset')?.addEventListener('click', e => { e.stopPropagation(); GHOST.loop.round=0; GHOST.loop.detail='↻ Drift guard reset'; render(); });
   $('#g-cnt-reset')?.addEventListener('click', () => {
     GHOST.loop.round = 0;
     Timeline.record('drift_guard_reset', { cap: GHOST.loop.maxRounds });
@@ -3119,6 +4192,8 @@ function bindEvents() {
   $('#wf-pause')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.workflow.pauseBetween=this.classList.contains('on'); _save('wfPause',GHOST.workflow.pauseBetween); render(); });
   $('#wf-reset')?.addEventListener('click', () => { GHOST.workflow.stageIndex=0; GHOST.workflow.active=GHOST.workflow.selected!=='none'; _save('wfStage',0); render(); });
   $('#wf-start')?.addEventListener('click', startWorkflow);
+  $('#wf-do-pause')?.addEventListener('click', () => { if(GHOST.loop.state==='RUNNING') pauseLoop(); });
+  $('#wf-do-stop')?.addEventListener('click', () => { GHOST.workflow.active=false; GHOST.workflow.stageIndex=0; _save('wfStage',0); stopLoop(); });
   $$('.g-wf-ins').forEach(b => b.addEventListener('click', () => {
     const wf = allWorkflows()[GHOST.workflow.selected] || WORKFLOW_LIBRARY.none;
     const stage = wf.stages[+b.dataset.ins];
@@ -3146,18 +4221,28 @@ function bindEvents() {
   });
 
   // Personas tab
-  $$('.g-persona-btn').forEach(b => b.addEventListener('click', (e) => {
-    if (e.target.closest('[data-del-p]')) return; // delete handled separately
-    GHOST.persona.selected=b.dataset.p; _save('persona',GHOST.persona.selected); render();
+  const _saveSel = () => { GHOST.persona._delivered = false; _save('persona', JSON.stringify(GHOST.persona.selected)); };
+  $('#p-comm-tog')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.persona.committee=this.classList.contains('on'); _save('personaCommittee',GHOST.persona.committee); if(GHOST.persona.committee&&GHOST.persona.selected.filter(s=>s&&s!=='none').length<2){ GHOST.persona.selected=GHOST.persona.selected.filter(s=>s&&s!=='none'); if(!GHOST.persona.selected.length) GHOST.persona.selected=['researcher','redteam']; _saveSel(); } render(); });
+  $('#p-single')?.addEventListener('change', e => { GHOST.persona.selected=[e.target.value]; _saveSel(); render(); });
+  $('#p-run')?.addEventListener('click', () => { GHOST.ui.tab='run'; startLoop(); });
+  $('#p-pertask')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.persona.perTask=this.classList.contains('on'); _save('personaPerTask',GHOST.persona.perTask); });
+  $('#p-review')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.persona.finalReview=this.classList.contains('on'); _save('personaFinalReview',GHOST.persona.finalReview); });
+  // Committee multi-select rows
+  $$('.g-cm-sel').forEach(sel => sel.addEventListener('change', e => {
+    const i=+sel.dataset.ci; const active=GHOST.persona.selected.filter(s=>s&&s!=='none');
+    if(i<active.length) active[i]=e.target.value;
+    GHOST.persona.selected=active.length?active:['none']; _saveSel(); render();
   }));
-  $$('[data-del-p]').forEach(x => x.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const id = x.dataset.delP;
-    if (x.dataset.confirm === '1') {
-      if (GHOST.persona.selected === id) { GHOST.persona.selected = 'none'; _save('persona','none'); }
-      Workshop.removePersona(id); render();
-    } else { x.dataset.confirm = '1'; x.textContent = '✓?'; x.title = 'Tap again to confirm delete'; }
+  $$('.g-cm-del').forEach(b => b.addEventListener('click', () => {
+    const i=+b.dataset.ci; const active=GHOST.persona.selected.filter(s=>s&&s!=='none');
+    active.splice(i,1); GHOST.persona.selected=active.length?active:['none']; _saveSel(); render();
   }));
+  $('#p-cm-add')?.addEventListener('click', () => {
+    const active=GHOST.persona.selected.filter(s=>s&&s!=='none');
+    const all=Object.keys(allPersonas()).filter(k=>k!=='none'&&!active.includes(k));
+    if(all.length) active.push(all[0]); GHOST.persona.selected=active; _saveSel(); render();
+  });
+  // Workshop: create/import/export (same as before, updated for array)
   $('#ws-p-new')?.addEventListener('click', () => { GHOST.ui.wsNewPersona = true; render(); });
   $('#ws-p-cancel')?.addEventListener('click', () => { GHOST.ui.wsNewPersona = false; render(); });
   $('#ws-p-save')?.addEventListener('click', () => {
@@ -3165,12 +4250,24 @@ function bindEvents() {
     const inject = ($('#ws-p-inject')?.value || '').trim();
     if (!label || !inject) { GHOST.loop.detail = '⚠ Name and framing are both required'; render(); return; }
     const id = Workshop.addPersona(label, inject);
-    GHOST.ui.wsNewPersona = false; GHOST.persona.selected = id; _save('persona', id);
+    GHOST.ui.wsNewPersona = false;
+    if(GHOST.persona.committee){ GHOST.persona.selected.push(id); } else { GHOST.persona.selected=[id]; }
+    _saveSel();
     GHOST.loop.detail = `✓ Created persona "${label}"`; render();
   });
   $('#ws-import')?.addEventListener('click', workshopImport);
   $('#ws-export')?.addEventListener('click', workshopExport);
-  $('#ws-submit')?.addEventListener('click', () => { GHOST.ui.prevTab = GHOST.ui.tab; GHOST.ui.helpSec = 'workshop'; GHOST.ui.tab = 'info'; render(); });
+  $('#ws-submit')?.addEventListener('click', () => {
+    // v8.1: Share now does the work — a paste-ready Discussions post (item
+    // list + JSON bundle) lands on the clipboard, then the how-to opens.
+    try {
+      const t = Workshop.shareText();
+      if (typeof GM_setClipboard === 'function') GM_setClipboard(t, { type:'text', mimetype:'text/plain' });
+      else navigator.clipboard?.writeText(t);
+      GHOST.loop.detail = '🌐 Share post copied — paste it into GitHub Discussions';
+    } catch(_) {}
+    GHOST.ui.prevTab = GHOST.ui.tab; GHOST.ui.helpSec = 'workshop'; GHOST.ui.tab = 'info'; render();
+  });
 
   // Export tab
   $('#exp-fmt')?.addEventListener('change', e => { GHOST.export.format=e.target.value; _save('expFormat',e.target.value); render(); });
@@ -3181,7 +4278,7 @@ function bindEvents() {
   $('#g-capsule')?.addEventListener('click', () => { exportCapsuleV2(); });
   $('#exp-think')?.addEventListener('click', function(){ this.classList.toggle('on'); GHOST.export.thinking=this.classList.contains('on'); _save('expThinking',GHOST.export.thinking); });
   $('#g-handoff')?.addEventListener('click', handoffInChat);
-  $('#g-rescue')?.addEventListener('click', exportRescue);
+  $('#g-rescue')?.addEventListener('click', exportBackupHandoff);
   $('#g-backup')?.addEventListener('click', backupConfig);
   $('#g-restore')?.addEventListener('click', () => $('#g-restore-file')?.click());
   $('#g-restore-file')?.addEventListener('change', e => {
@@ -3230,10 +4327,36 @@ function bindEvents() {
     catch(err) { if(st) st.textContent='⚠ Invalid JSON — not saved.'; }
   });
   $('#cfg-qs')?.addEventListener('click', () => { GHOST.ui.firstRun=true; _save('firstRun',true); GHOST.ui.tab='run'; render(); });
+  $('#cfg-unattended')?.addEventListener('click', function(){
+    this.classList.toggle('on');
+    GHOST.ui.unattended = this.classList.contains('on');
+    _save('unattended', GHOST.ui.unattended);
+    // Re-arm the ticker on the new mode if a run is live.
+    if (GHOST.loop.state === 'RUNNING') GHOST.loop.timer = Ticker.start(engineTick, 2500);
+    GHOST.loop.detail = GHOST.ui.unattended
+      ? '🌙 Unattended ON — keeps running in a background tab'
+      : 'Unattended OFF — pauses when you switch away';
+    render();
+  });
+  $('#cfg-skin')?.addEventListener('change', e => {
+    const v = e.target.value;
+    if (v === 'custom' && !GHOST.ui.customSkin) { SKIN.importFile(); render(); return; }
+    GHOST.ui.skinTheme = v; _save('skinTheme', v); SKIN.apply(); render();
+  });
+  $('#cfg-skin-imp')?.addEventListener('click', () => SKIN.importFile());
+  $('#cfg-skin-exp')?.addEventListener('click', () => SKIN.exportCurrent());
+  $$('.g-swatch').forEach(b => b.addEventListener('click', () => {
+    const h = parseInt(b.dataset.hue, 10);
+    GHOST.ui.accentHue = h; _save('accentHue', h); SKIN.apply(); render();
+  }));
+  $('#cfg-hue')?.addEventListener('dblclick', () => { GHOST.ui.accentHue = NaN; _save('accentHue',''); SKIN.apply(); render(); });
+  $('#cfg-hue')?.addEventListener('input', e => { GHOST.ui.accentHue=parseInt(e.target.value,10); _save('accentHue',GHOST.ui.accentHue); SKIN.apply(); render(); });
   $('#g-redetect')?.addEventListener('click', function(){
     this.classList.add('spin');
     const ok = reDetect();
-    setTimeout(() => this.classList.remove('spin'), 600);
+    // Found immediately → brief spin. Otherwise the async watcher keeps the
+    // spin going and clears it itself on success or 12s timeout.
+    if (ok) setTimeout(() => this.classList.remove('spin'), 600);
   });
   $('#g-info')?.addEventListener('click', () => { GHOST.ui.tab = GHOST.ui.tab==='info' ? 'run' : 'info'; render(); });
   $('#g-info-back')?.addEventListener('click', () => { GHOST.ui.tab = GHOST.ui.prevTab || 'run'; GHOST.ui.prevTab = null; render(); });
@@ -3292,7 +4415,29 @@ safeBoot(() => {
   Workshop.load();
   injectStyles();
   mountPanel();
+  SKIN.apply();
   render();
+
+  // SPA boot retry: ChatGPT/Gemini/Angular apps render chat elements late.
+  // Keep trying to find input+send for 30s after boot (every 2s).
+  // Once found, update status and stop retrying.
+  let _bootRetry = 0;
+  const _bootInterval = setInterval(() => {
+    _bootRetry++;
+    const inp = _q('input', PLAT.input);
+    if (inp) {
+      clearInterval(_bootInterval);
+      GHOST.loop.detail = `✓ Connected to ${PLAT.label}`;
+      render();
+      DIAG.push(`Boot: elements found after ${_bootRetry * 2}s`);
+    } else if (_bootRetry >= 15) {
+      clearInterval(_bootInterval);
+      DIAG.push('Boot: gave up waiting for elements after 30s');
+    } else {
+      // Re-attempt detect during SPA hydration
+      _cache.clear();
+    }
+  }, 2000);
   Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8) });
   console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}`);
 });

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -22,6 +22,7 @@ function GM_notification(detail) {
   } catch(_){}
 }
 _initStore().then(() => {
+
 (() => {
 'use strict';
 /* v8.2.0 transactional boot: do NOT commit the singleton here. Committing it
@@ -79,7 +80,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.2.0';
+const VER = '8.2.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -691,7 +692,13 @@ const SEND_WORDS = /send|submit|发送|傳送|送信|보내기|enviar|envoyer|se
    clicked the reply's "Copy" button (svg icon + proximity alone scored past
    the old threshold) and the user's prompt got copied instead of sent.
    Message-action verbs are now hard-vetoed on EVERY send tier. */
-const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research/i;
+/* v8.2.1: added model/plus/tool/option after issues #4 and #5 — the heuristic
+   tier learned a WRONG send control on two sites because it lived inside the
+   composer form (the "same-form" signal alone qualified it): #model-select-
+   trigger on Grok and #composer-plus-btn on ChatGPT. Their ids/labels are now
+   vetoed too, and a structural popup-toggle check (below) catches the general
+   case regardless of wording. */
+const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research|model|plus\b|tool|option|picker|dropdown|emoji|format/i;
 
 /* A candidate send control must clear the veto no matter which tier found
    it — configured selectors can rot into matching the wrong control after
@@ -699,8 +706,18 @@ const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings
 function _sendLooksSafe(el) {
   if (!el) return false;
   try {
-    const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
-                   el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
+    /* v8.2.1 structural gate (issues #4/#5): a send button submits — it never
+       opens a menu or toggles a disclosure. Model pickers, the "+" attach menu
+       and tool dropdowns all carry aria-haspopup and/or aria-expanded. This
+       one check kills #model-select-trigger (Grok) and #composer-plus-btn
+       (ChatGPT) no matter how they are labelled. */
+    if (el.getAttribute('aria-haspopup')) return false;
+    if (el.getAttribute('aria-expanded') != null) return false;
+    /* id is telltale on both field mislearns ("model-select", "plus-btn") yet
+       was never inspected before — fold it into the veto surface. */
+    const label = [el.getAttribute('id'), el.getAttribute('aria-label'),
+                   el.getAttribute('title'), el.getAttribute('data-testid'),
+                   el.textContent].join(' ').slice(0, 160);
     return !SEND_VETO.test(label);
   } catch(_) { return true; }
 }
@@ -748,7 +765,10 @@ function _heurSend(anchor) {
     if (!_visible(el) || el.disabled || el.getAttribute('aria-disabled') === 'true') continue;
     const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
                    el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
-    if (SEND_VETO.test(label)) continue; // hard veto — a wrong click (mic, attach) is worse than no click
+    // Single veto gate (v8.2.1): _sendLooksSafe now also inspects id and rejects
+    // popup-toggles (aria-haspopup/aria-expanded), so a wrong click (mic, attach,
+    // model-picker, "+") is filtered here too — worse than no click at all.
+    if (!_sendLooksSafe(el)) continue;
     /* v8.1 semantic gate: proximity + an svg icon must NEVER be enough on
        their own (that combination is every message-action button on the
        page). A candidate needs at least one POSITIVE send signal. */

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -72,10 +72,41 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.4';
+const VER = '8.1.5';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
+
+/* ═══════════════════════════════════════════════════════════════
+   TRUSTED TYPES (v8.1.5) — the actual Gemini root cause
+   Gemini (a Google property) enforces `require-trusted-types-for 'script'`.
+   Under that CSP, assigning a plain string to `.innerHTML` THROWS
+   ("Sink type mismatch violation blocked by CSP" in Firefox) — which killed
+   boot on the very first render and is why the panel never appeared on
+   Gemini specifically (no other supported platform enforces Trusted Types).
+   Confirmed from the v8.1.4 fail-loud banner on the reporter's device.
+   Fix: register one policy at boot and route GITL's 4 innerHTML sinks through
+   it. On every site that does NOT enforce Trusted Types, `_ttPolicy` stays
+   null and `_TT()` returns the raw string — byte-identical behaviour, zero
+   regression risk off Gemini. GITL only ever passes its OWN static templates
+   here (persona/workflow text is already escaped via _esc upstream), so the
+   pass-through policy introduces no new injection surface. */
+let _ttPolicy = null;
+try {
+  if (typeof window !== 'undefined' && window.trustedTypes && window.trustedTypes.createPolicy) {
+    // A per-script named policy — page-scoped, does NOT touch the page's own
+    // default policy or other code. Name kept unique to avoid collisions.
+    _ttPolicy = window.trustedTypes.createPolicy('gitl-ui', { createHTML: (s) => s });
+  }
+} catch (e) {
+  // A restrictive `trusted-types` allow-list can forbid creating our policy.
+  // Record it (surfaces via the beacon/banner) — the panel would then need a
+  // DOM-built fallback, tracked as follow-up. Never fatal here.
+  _ttPolicy = null;
+  try { _beacon('tt-policy-blocked'); } catch(_) {}
+}
+/* Wrap any HTML string destined for an innerHTML sink. */
+function _TT(s) { return _ttPolicy ? _ttPolicy.createHTML(s) : s; }
 const SIGIL_PROCEED = '[[GITL::PROCEED]]';
 const SIGIL_HALT    = '[[GITL::HALT]]';
 const LEGACY_PROCEED = 'PROCEED';
@@ -2596,7 +2627,7 @@ const VEIL = {
     // immune to z-index wars and transform-based parents. Feature-detected.
     this._popover = typeof this.el.showPopover === 'function';
     if (this._popover) { try { this.el.setAttribute('popover', 'manual'); } catch(_) { this._popover = false; } }
-    this.el.innerHTML = `
+    this.el.innerHTML = _TT(`
       <div class="gv-card">
         <div class="gv-ringwrap">
           <div class="gv-ghost-x gv-gx1">👻</div>
@@ -2611,7 +2642,7 @@ const VEIL = {
         <div class="gv-pct" id="gv-pct"></div>
         <div class="gv-note" id="gv-note">Please don't reload the page</div>
         <button class="gv-cancel" id="gv-cancel">Cancel</button>
-      </div>`;
+      </div>`);
     document.body.appendChild(this.el);
     this.el.querySelector('#gv-cancel').addEventListener('click', () => { this.cancelled = true; this.el.querySelector('#gv-title').textContent = 'Stopping…'; });
     // Re-assert top-layer if the tab was backgrounded (mobile browsers can drop
@@ -2669,8 +2700,8 @@ const VEIL = {
     this.renderSteps(); this.beat(null);
   },
   renderSteps() {
-    this.el.querySelector('#gv-steps').innerHTML = this.steps.map((s, i) =>
-      `<div class="gv-step${i < this.idx ? ' done' : i === this.idx ? ' act' : ''}">${i < this.idx ? '✓' : i === this.idx ? '▶' : '·'} ${s}</div>`).join('');
+    this.el.querySelector('#gv-steps').innerHTML = _TT(this.steps.map((s, i) =>
+      `<div class="gv-step${i < this.idx ? ' done' : i === this.idx ? ' act' : ''}">${i < this.idx ? '✓' : i === this.idx ? '▶' : '·'} ${s}</div>`).join(''));
   },
   beat(pct) {
     this.lastBeat = Date.now();
@@ -3708,7 +3739,7 @@ function _explainLookup(target) {
 function _explainShow(info) {
   let tip = panel.querySelector('.g-xtip');
   if (!tip) { tip = document.createElement('div'); tip.className = 'g-xtip'; panel.appendChild(tip); }
-  tip.innerHTML = `<span class="x" id="g-xtip-x">✕</span><b>${info.name}</b><br>${info.desc}`;
+  tip.innerHTML = _TT(`<span class="x" id="g-xtip-x">✕</span><b>${info.name}</b><br>${info.desc}`);
 }
 function _explainIntercept(e) {
   const t = e.target;
@@ -4168,7 +4199,7 @@ function render() {
       : '';
     return [bar, line1, line2].filter(Boolean).join('');
   })();
-  panel.innerHTML = `
+  panel.innerHTML = _TT(`
     <div class="g-hdr" id="g-drag">
       <span class="g-logo">${col && GHOST.ui.position==='dock-left' ? '☰ Ghost' : '<span class="g-ghost">👻</span> Ghost'}<span class="g-dot ${dotClass()}"></span></span>
       <span style="display:flex;align-items:center;gap:5px">
@@ -4203,7 +4234,7 @@ function render() {
         ${tab==='personas'?renderPersonasTab():''}${tab==='export'?renderExportTab():''}
         ${tab==='settings'?renderSettingsTab():''}
       </div>
-    </div>`;
+    </div>`);
   bindEvents();
   applyPosition(GHOST.ui.position);
 }

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -30,7 +30,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.1';
+const VER = '8.1.2';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -1996,7 +1996,20 @@ function engineTick() {
 
   // Read output
   const text = Adapter.getLastText();
-  if (!text) { L.staleTicks++; if (L.staleTicks >= 5) pauseWithProbe('No output detected'); return; }
+  if (!text) {
+    /* v8.1.2 field report (Perplexity Deep Research): this branch fires
+       before the FIRST assistant DOM node exists at all — during a long
+       silent "thinking" phase there is no text to read yet, but net traffic
+       or a stop button proves the model is working. The later no-signal
+       branch already got this isGenerating() witness + per-platform budget
+       in d7; this earlier branch was missed, so slow-starting platforms
+       could still pause ~12s after a perfectly good send. */
+    if (Adapter.isGenerating()) { L.staleTicks = 0; L.detail = '🧠 Model is still working…'; render(); return; }
+    L.staleTicks++;
+    const staleLimit = (PLAT && PLAT.staleTicks) || 5;
+    if (L.staleTicks >= staleLimit) pauseWithProbe('No output detected');
+    return;
+  }
 
   // Detect signal
   const result = detectSignal(text);
@@ -2270,9 +2283,25 @@ function primaryAction() {
 window.addEventListener('popstate', () => window.dispatchEvent(new Event('gitl:route')));
 window.addEventListener('gitl:route', () => {
   if (location.href !== _lastHref) {
+    const prevHref = _lastHref;
     _lastHref = location.href;
     _clearElementCaches();
-    if (GHOST.loop.state === 'RUNNING') enginePause('Route changed — paused');
+    if (GHOST.loop.state === 'RUNNING') {
+      /* v8.1.2 field report (Grok): almost every platform assigns a fresh
+         conversation URL (e.g. "/" -> "/c/<uuid>") the instant the FIRST
+         message is sent — that is normal same-conversation continuation,
+         not navigating away, but it used to pause every run one tick after
+         it started. Only treat it as a real navigation-away when the host
+         changed, or when nothing was sent recently to explain the URL move. */
+      let sameHost = false;
+      try { sameHost = new URL(prevHref).hostname === location.hostname; } catch(_) {}
+      const justSent = GHOST.loop.sendPending || (Date.now() - (GHOST.loop.lastActivity || 0) < 15000);
+      if (sameHost && justSent) {
+        Timeline.record('route_id_assigned', { from: prevHref, to: location.href });
+        return;
+      }
+      enginePause('Route changed — paused');
+    }
   }
 });
 

--- a/dev/extension/content.js
+++ b/dev/extension/content.js
@@ -30,7 +30,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.2';
+const VER = '8.1.3';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -273,11 +273,23 @@ const GITL_NET = {
   install() {
     if (this.active) return;
     this.active = true;
+    /* v8.1.3 field report (Gemini "doesn't load"): install() used to run
+       fully unguarded at module top-level, OUTSIDE safeBoot()'s try/catch
+       (which only wraps panel creation much further down). In strict mode,
+       reassigning a property a host page has hardened (Object.defineProperty
+       with writable:false — a real pattern on security-conscious Google
+       properties) throws a TypeError right here, which aborts the ENTIRE
+       script before a single line of panel code runs: no #gitl, no console
+       message a normal user would ever see, nothing. Every patch below is
+       now individually fault-tolerant, and the whole method is wrapped too,
+       so one hardened site can only cost that site's network telemetry —
+       never the panel. */
+    try {
 
     /* Fetch proxy on the PAGE window — captures SSE / JSON streams */
     const self = this;
-    const origFetch = UW.fetch;
-    if (typeof origFetch === 'function') UW.fetch = async function(...args) {
+    let origFetch; try { origFetch = UW.fetch; } catch(_) { origFetch = null; }
+    try { if (typeof origFetch === 'function') UW.fetch = async function(...args) {
       const response = await origFetch.apply(this, args);
       const listed = self._isChat(args[0]);
       let heur = false;
@@ -332,33 +344,35 @@ const GITL_NET = {
         }
       }
       return response;
-    };
+    }; } catch(err) { console.warn('[GITL] fetch patch skipped:', err); }
 
     /* XHR proxy on the PAGE window — Gemini streams via batchexecute XHRs */
-    const XP = (UW.XMLHttpRequest && UW.XMLHttpRequest.prototype) || null;
-    if (XP && XP.open && XP.send) {
-      const origOpen = XP.open;
-      XP.open = function(method, url, ...rest) {
-        this._gitlUrl = url; this._gitlMethod = method;
-        return origOpen.call(this, method, url, ...rest);
-      };
-      const origSend = XP.send;
-      XP.send = function(...args) {
-        const listed = self._isChat(this._gitlUrl);
-        const heur = !listed && self._maybeChat(this._gitlUrl, this._gitlMethod);
-        if (listed || heur) {
-          try {
-            this.addEventListener('loadstart', () => { self._open++; self._pulse(listed); });
-            this.addEventListener('progress',  () => self._pulse(listed));
-            this.addEventListener('loadend',   () => { self._open = Math.max(0, self._open - 1); self._pulse(listed); });
-            if (listed) this.addEventListener('load', function() {
-              if (this.status >= 200 && this.status < 300 && this.responseText) self._emit(this.responseText, true);
-            });
-          } catch(_) {}
-        }
-        return origSend.apply(this, args);
-      };
-    }
+    try {
+      const XP = (UW.XMLHttpRequest && UW.XMLHttpRequest.prototype) || null;
+      if (XP && XP.open && XP.send) {
+        const origOpen = XP.open;
+        XP.open = function(method, url, ...rest) {
+          this._gitlUrl = url; this._gitlMethod = method;
+          return origOpen.call(this, method, url, ...rest);
+        };
+        const origSend = XP.send;
+        XP.send = function(...args) {
+          const listed = self._isChat(this._gitlUrl);
+          const heur = !listed && self._maybeChat(this._gitlUrl, this._gitlMethod);
+          if (listed || heur) {
+            try {
+              this.addEventListener('loadstart', () => { self._open++; self._pulse(listed); });
+              this.addEventListener('progress',  () => self._pulse(listed));
+              this.addEventListener('loadend',   () => { self._open = Math.max(0, self._open - 1); self._pulse(listed); });
+              if (listed) this.addEventListener('load', function() {
+                if (this.status >= 200 && this.status < 300 && this.responseText) self._emit(this.responseText, true);
+              });
+            } catch(_) {}
+          }
+          return origSend.apply(this, args);
+        };
+      }
+    } catch(err) { console.warn('[GITL] XHR patch skipped:', err); }
 
     /* WebSocket pulse — Perplexity's socket.io traffic (timestamps only) */
     try {
@@ -371,14 +385,20 @@ const GITL_NET = {
           }
         });
       }
-    } catch(_) {}
+    } catch(err) { console.warn('[GITL] WebSocket patch skipped:', err); }
 
     console.log('[GITL] Network interceptor active');
+    } catch(err) {
+      console.error('[GITL] Network interceptor failed to install — panel will still boot:', err);
+      try { GM_setValue('lastNetInstallError', JSON.stringify({ msg: String(err?.message||err), at: new Date().toISOString() })); } catch(_) {}
+    }
   }
 };
 
-/* Install immediately — safe even before DOM */
-GITL_NET.install();
+/* Install immediately — safe even before DOM. Also guarded at the call site:
+   this runs before safeBoot() and used to be able to take the whole script
+   down with it (see the v8.1.3 note inside install()). */
+try { GITL_NET.install(); } catch(err) { console.error('[GITL] GITL_NET.install() threw at top level — continuing boot anyway:', err); }
 
 /* ═══════════════════════════════════════════════════════════════
    LAYER 1 — PLATFORM ADAPTERS (all DOM access lives here)
@@ -4469,6 +4489,20 @@ safeBoot(() => {
   }, 2000);
   Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8) });
   console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}`);
+
+  /* v8.1.3: surface a PRIOR boot failure once, instead of it living silently
+     in GM storage forever. Reaching this line means boot succeeded THIS
+     time (the panel you're looking at is proof), so this only fires for a
+     failure on an earlier page load — e.g. a hardened page killed the whole
+     script before install() was made fault-tolerant. Visible in the
+     Diagnostics probe / any auto-report from here on, then cleared so it
+     doesn't repeat every boot. */
+  try {
+    const lastBoot = GM_getValue('lastBootError', '');
+    const lastNet  = GM_getValue('lastNetInstallError', '');
+    if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
+    if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
+  } catch(_) {}
 });
 })();
 });

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.0.0.13",
+  "version": "8.1.0",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.5",
+  "version": "8.2.0",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/extension/manifest.json
+++ b/dev/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "\ud83d\udc7b AI workflow engine \u2014 boot safety, network intercept, recovery engine, capsule v2, diagnostics.",
   "permissions": [
     "storage"

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -4601,7 +4601,7 @@ safeBoot(() => {
   _phase('heartbeat', false, () => startTabHeartbeat());
   _phase('tab-lock',  false, () => claimTabLock());
   _phase('bus',       false, () => GhostBus.init());
-  _phase('panel-sentinel', false, () => startPanelWatchdog());
+  _phase('panel-sentinel', false, () => startPanelSentinel());
 
   _phase('boot-retry', false, () => {
     // SPA boot retry: ChatGPT/Gemini/Angular render chat elements late; keep
@@ -4638,24 +4638,89 @@ safeBoot(() => {
   console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}` + (GHOST._degraded.length ? ` | degraded:${GHOST._degraded.join(',')}` : ''));
 });
 
-/* Re-mounts the panel if the page framework removes it from the DOM. */
-function startPanelWatchdog() {
-  let remounts = 0;
+/* PANEL SENTINEL (v8.2.0) — bounded, visibility-aware panel liveness.
+   Replaces the v8.1.4 watchdog, which only checked ABSENCE and had no cap, so
+   a page that re-hid the panel each time could drive an unbounded
+   append/remove storm. This version:
+     • treats the panel as "down" when it is disconnected, in a display:none /
+       visibility:hidden subtree, or has zero size (host may move #gitl into a
+       hidden container rather than remove it) — re-appending to document.body
+       rescues all of those. NOTE: safe because GITL never hides its OWN root
+       (collapsed state only hides the inner .g-body; the root keeps ≥44px);
+     • debounces, and CAPS remounts within a rolling window;
+     • on exceeding the cap, OPENS A CIRCUIT BREAKER: stops observing and shows
+       a visible, dismissible note instead of thrashing forever;
+     • disconnects observers/timers on teardown. */
+function startPanelSentinel() {
+  const MAX = 5, WINDOW_MS = 30000, DEBOUNCE_MS = 120;
+  let mo = null, poll = null, scheduled = null, opened = false;
+  const times = [];
+
+  const isDown = () => {
+    const n = document.getElementById('gitl');
+    if (!n || !n.isConnected || !document.body) return true;
+    try {
+      const st = getComputedStyle(n);
+      if (st.display === 'none' || st.visibility === 'hidden') return true;
+      const r = n.getBoundingClientRect();
+      if (r.width <= 2 && r.height <= 2) return true;
+    } catch(_) {}
+    return false;
+  };
+
+  const teardown = () => {
+    try { mo && mo.disconnect(); } catch(_) {}
+    if (poll) clearInterval(poll);
+    if (scheduled) clearTimeout(scheduled);
+    mo = poll = scheduled = null;
+  };
+
+  const openBreaker = () => {
+    opened = true;
+    teardown();
+    _beacon('sentinel-open');
+    Timeline.record('panel_circuit_open', { remounts: times.length, windowMs: WINDOW_MS });
+    try { DIAG.push('Panel sentinel opened: the page kept removing/hiding the panel — stopped re-mounting to avoid a loop.'); } catch(_) {}
+    // Visible, dismissible note (reuses the fatal-banner style, distinct id).
+    try {
+      if (document.getElementById('gitl-sentinel')) return;
+      const b = document.createElement('div');
+      b.id = 'gitl-sentinel';
+      b.setAttribute('style', 'position:fixed;top:0;left:0;right:0;z-index:2147483646;background:#2a230a;color:#ffe6a6;font:600 12px/1.4 system-ui,sans-serif;padding:9px 32px 9px 12px;border-bottom:2px solid #d9a441;white-space:pre-wrap');
+      b.textContent = "👻 Ghost's panel keeps being removed by this page, so it stopped re-adding it. Tap 🔄 re-detect or reload to try again.";
+      const x = document.createElement('span');
+      x.textContent = '×';
+      x.setAttribute('style', 'position:absolute;top:5px;right:10px;cursor:pointer;font-size:18px;line-height:1');
+      x.addEventListener('click', () => b.remove());
+      b.appendChild(x);
+      (document.body || document.documentElement).appendChild(b);
+    } catch(_) {}
+  };
+
   const ensure = () => {
-    if (document.getElementById('gitl') || !document.body) return;
-    // Panel vanished — re-append the SAME node (state/handlers intact).
+    if (opened || !isDown()) return;
+    const now = Date.now();
+    while (times.length && now - times[0] > WINDOW_MS) times.shift();
+    if (times.length >= MAX) { openBreaker(); return; }
+    times.push(now);
+    // Re-append the SAME node (state + event handlers intact).
     _panelMounted = false;
     mountPanel();
-    remounts++;
-    _beacon('remounted:' + remounts);
-    Timeline.record('panel_remount', { count: remounts });
-    DIAG.push('Panel was removed by the page — re-mounted (#' + remounts + ')');
+    _beacon('remounted:' + times.length);
+    Timeline.record('panel_remount', { count: times.length });
+    try { DIAG.push('Panel was removed/hidden by the page — re-mounted (#' + times.length + ')'); } catch(_) {}
     render();
   };
-  const mo = new MutationObserver(ensure);
+
+  const schedule = () => {
+    if (opened || scheduled) return;
+    scheduled = setTimeout(() => { scheduled = null; ensure(); }, DEBOUNCE_MS);
+  };
+
+  mo = new MutationObserver(schedule);
   mo.observe(document.documentElement, { childList: true, subtree: true });
-  // Belt-and-suspenders: a slow poll in case a body swap escapes the observer.
-  setInterval(ensure, 3000);
+  // Belt-and-suspenders: catch body swaps / CSS-only hides the observer may miss.
+  poll = setInterval(ensure, 3000);
 }
 
 } catch(__gitlBootErr) { _gitlFatal('top-level', __gitlBootErr); }

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -46,8 +46,15 @@
 
 (() => {
 'use strict';
-if (window.__GITL_V8__) return;
-window.__GITL_V8__ = true;
+/* v8.2.0 transactional boot: do NOT commit the singleton here. Committing it
+   before boot succeeded meant a partial/failed boot (e.g. the Trusted Types
+   throw) permanently blocked any same-page retry. `window.__GITL_V8__` is now
+   set to `true` only after the CRITICAL UI phases (styles → panel → render)
+   succeed. A short in-flight marker prevents concurrent double-execution
+   without poisoning a retry after a failed attempt. */
+if (window.__GITL_V8__ === true) return;                                          // already fully booted
+if (window.__GITL_BOOTING__ && Date.now() - window.__GITL_BOOTING__ < 15000) return; // an attempt is in flight
+window.__GITL_BOOTING__ = Date.now();
 
 /* ═══════════════════════════════════════════════════════════════
    BOOT BEACON + FAIL-LOUD (v8.1.4)
@@ -2391,6 +2398,9 @@ function primaryAction() {
    SPA ROUTE DETECTION
    ═══════════════════════════════════════════════════════════════ */
 (function patchHistory() {
+  // Guarded so a boot retry (top-level code re-running) can't double-wrap.
+  if (window.__GITL_HIST_PATCHED__) return;
+  window.__GITL_HIST_PATCHED__ = true;
   const orig = history.pushState;
   history.pushState = function(...a) { orig.apply(this, a); window.dispatchEvent(new Event('gitl:route')); };
   const origR = history.replaceState;
@@ -4539,76 +4549,93 @@ let _mutDebounce;
    BOOT — wrapped in safeBoot to prevent v7.0-alpha loading failures
    ═══════════════════════════════════════════════════════════════ */
 safeBoot(() => {
-  // Observer watches childList (new nodes) AND a narrow set of attributes
-  // (style/class/hidden), so a Continue button revealed via CSS — not just
-  // one freshly inserted — also triggers the auto-click fast-path.
-  // Loop tick (setInterval) remains the primary driver; this is a fast-path.
-  new MutationObserver(() => {
-    if (GHOST.loop.state !== 'RUNNING' || GHOST.loop.isSending) return;
-    clearTimeout(_mutDebounce);
-    _mutDebounce = setTimeout(() => { GHOST.loop.lastActivity = Date.now(); Adapter.clickContinue(); }, 300);
-  }).observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['style', 'class', 'hidden', 'disabled', 'aria-hidden']
+  /* v8.2.0 TRANSACTIONAL BOOT.
+     Previously boot was one straight-line block: any throw before mountPanel()
+     — including in an OPTIONAL subsystem like the tab bus or heartbeat — aborted
+     the rest and the panel never appeared. Now boot runs as isolated phases:
+       • CRITICAL phases (styles → panel → render) must succeed; a failure is
+         fatal AND loud (_gitlFatal via safeBoot's catch).
+       • OPTIONAL phases are each caught: one failing subsystem degrades health
+         and is logged, but can never suppress the panel or the phases after it.
+     The singleton `window.__GITL_V8__` is committed only after the critical
+     phases succeed, so a failed attempt no longer blocks a retry. */
+  GHOST._degraded = [];
+  const _phase = (name, critical, fn) => {
+    const t = Date.now();
+    try {
+      fn();
+      Timeline.record('boot_phase', { name, ok: true, ms: Date.now() - t });
+    } catch (e) {
+      Timeline.record('boot_phase', { name, ok: false, error: String(e && e.message || e) });
+      if (critical) throw new Error('critical boot phase "' + name + '" failed: ' + (e && e.message || e));
+      GHOST._degraded.push(name);
+      try { DIAG.push('Boot phase "' + name + '" failed (non-critical, panel unaffected): ' + (e && e.message || e)); } catch(_) {}
+    }
+  };
+
+  // ── CRITICAL: get the panel on screen. Nothing optional runs before this. ──
+  _phase('workshop', false, () => Workshop.load());   // custom items for first render; non-fatal if it throws
+  _phase('styles',   true,  () => injectStyles());
+  _phase('panel',    true,  () => mountPanel());
+  _phase('skin',     true,  () => SKIN.apply());
+  _phase('render',   true,  () => render());
+
+  // Panel is up and rendered — commit the singleton NOW (never before boot).
+  window.__GITL_V8__ = true;
+  window.__GITL_BOOTING__ = 0;
+  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
+
+  // ── OPTIONAL: isolated. None of these can remove the panel if they throw. ──
+  _phase('continue-observer', false, () => {
+    // Fast-path: a Continue button revealed via CSS (not just freshly inserted)
+    // also triggers the auto-click. The loop tick remains the primary driver.
+    new MutationObserver(() => {
+      if (GHOST.loop.state !== 'RUNNING' || GHOST.loop.isSending) return;
+      clearTimeout(_mutDebounce);
+      _mutDebounce = setTimeout(() => { GHOST.loop.lastActivity = Date.now(); Adapter.clickContinue(); }, 300);
+    }).observe(document.body, {
+      childList: true, subtree: true, attributes: true,
+      attributeFilter: ['style', 'class', 'hidden', 'disabled', 'aria-hidden']
+    });
+  });
+  _phase('heartbeat', false, () => startTabHeartbeat());
+  _phase('tab-lock',  false, () => claimTabLock());
+  _phase('bus',       false, () => GhostBus.init());
+  _phase('panel-sentinel', false, () => startPanelWatchdog());
+
+  _phase('boot-retry', false, () => {
+    // SPA boot retry: ChatGPT/Gemini/Angular render chat elements late; keep
+    // trying to find input+send for 30s (every 2s), then stop.
+    let _bootRetry = 0;
+    const _bootInterval = setInterval(() => {
+      _bootRetry++;
+      const inp = _q('input', PLAT.input);
+      if (inp) {
+        clearInterval(_bootInterval);
+        GHOST.loop.detail = `✓ Connected to ${PLAT.label}`;
+        render();
+        DIAG.push(`Boot: elements found after ${_bootRetry * 2}s`);
+      } else if (_bootRetry >= 15) {
+        clearInterval(_bootInterval);
+        DIAG.push('Boot: gave up waiting for elements after 30s');
+      } else {
+        _cache.clear(); // re-attempt detect during SPA hydration
+      }
+    }, 2000);
   });
 
-  startTabHeartbeat();
-  claimTabLock();
-  GhostBus.init();
-  Workshop.load();
-  injectStyles();
-  mountPanel();
-  SKIN.apply();
-  render();
-
-  // SPA boot retry: ChatGPT/Gemini/Angular apps render chat elements late.
-  // Keep trying to find input+send for 30s after boot (every 2s).
-  // Once found, update status and stop retrying.
-  let _bootRetry = 0;
-  const _bootInterval = setInterval(() => {
-    _bootRetry++;
-    const inp = _q('input', PLAT.input);
-    if (inp) {
-      clearInterval(_bootInterval);
-      GHOST.loop.detail = `✓ Connected to ${PLAT.label}`;
-      render();
-      DIAG.push(`Boot: elements found after ${_bootRetry * 2}s`);
-    } else if (_bootRetry >= 15) {
-      clearInterval(_bootInterval);
-      DIAG.push('Boot: gave up waiting for elements after 30s');
-    } else {
-      // Re-attempt detect during SPA hydration
-      _cache.clear();
-    }
-  }, 2000);
-  Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8) });
-  console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}`);
-
-  /* v8.1.3: surface a PRIOR boot failure once, instead of it living silently
-     in GM storage forever. Reaching this line means boot succeeded THIS
-     time (the panel you're looking at is proof), so this only fires for a
-     failure on an earlier page load — e.g. a hardened page killed the whole
-     script before install() was made fault-tolerant. Visible in the
-     Diagnostics probe / any auto-report from here on, then cleared so it
-     doesn't repeat every boot. */
-  try {
+  _phase('prior-error-surface', false, () => {
+    /* Surface a PRIOR boot failure once (from GM storage), then clear it, so a
+       failure on an earlier load becomes visible in Diagnostics/reports now
+       that the panel is up. */
     const lastBoot = GM_getValue('lastBootError', '');
     const lastNet  = GM_getValue('lastNetInstallError', '');
     if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
     if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
-  } catch(_) {}
+  });
 
-  // Boot completed AND the panel is in the DOM — record success on the beacon.
-  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
-  // Panel self-heal: Gemini's Angular framework (and some other SPAs) can
-  // wipe document.body's children out from under us on route/re-render,
-  // silently removing #gitl with no error thrown — a leading suspect for
-  // "installed and active but nothing shows up" on Gemini specifically.
-  // Watch for the panel disappearing and re-mount it. Cheap: one observer,
-  // only acts when #gitl is actually gone.
-  try { startPanelWatchdog(); } catch(e) { DIAG.push('panel watchdog failed: ' + e); }
+  Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8), degraded: GHOST._degraded });
+  console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}` + (GHOST._degraded.length ? ` | degraded:${GHOST._degraded.join(',')}` : ''));
 });
 
 /* Re-mounts the panel if the page framework removes it from the DOM. */

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.2.0
+// @version      8.2.1
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -101,7 +101,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.2.0';
+const VER = '8.2.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -713,7 +713,13 @@ const SEND_WORDS = /send|submit|发送|傳送|送信|보내기|enviar|envoyer|se
    clicked the reply's "Copy" button (svg icon + proximity alone scored past
    the old threshold) and the user's prompt got copied instead of sent.
    Message-action verbs are now hard-vetoed on EVERY send tier. */
-const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research/i;
+/* v8.2.1: added model/plus/tool/option after issues #4 and #5 — the heuristic
+   tier learned a WRONG send control on two sites because it lived inside the
+   composer form (the "same-form" signal alone qualified it): #model-select-
+   trigger on Grok and #composer-plus-btn on ChatGPT. Their ids/labels are now
+   vetoed too, and a structural popup-toggle check (below) catches the general
+   case regardless of wording. */
+const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research|model|plus\b|tool|option|picker|dropdown|emoji|format/i;
 
 /* A candidate send control must clear the veto no matter which tier found
    it — configured selectors can rot into matching the wrong control after
@@ -721,8 +727,18 @@ const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings
 function _sendLooksSafe(el) {
   if (!el) return false;
   try {
-    const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
-                   el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
+    /* v8.2.1 structural gate (issues #4/#5): a send button submits — it never
+       opens a menu or toggles a disclosure. Model pickers, the "+" attach menu
+       and tool dropdowns all carry aria-haspopup and/or aria-expanded. This
+       one check kills #model-select-trigger (Grok) and #composer-plus-btn
+       (ChatGPT) no matter how they are labelled. */
+    if (el.getAttribute('aria-haspopup')) return false;
+    if (el.getAttribute('aria-expanded') != null) return false;
+    /* id is telltale on both field mislearns ("model-select", "plus-btn") yet
+       was never inspected before — fold it into the veto surface. */
+    const label = [el.getAttribute('id'), el.getAttribute('aria-label'),
+                   el.getAttribute('title'), el.getAttribute('data-testid'),
+                   el.textContent].join(' ').slice(0, 160);
     return !SEND_VETO.test(label);
   } catch(_) { return true; }
 }
@@ -770,7 +786,10 @@ function _heurSend(anchor) {
     if (!_visible(el) || el.disabled || el.getAttribute('aria-disabled') === 'true') continue;
     const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
                    el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
-    if (SEND_VETO.test(label)) continue; // hard veto — a wrong click (mic, attach) is worse than no click
+    // Single veto gate (v8.2.1): _sendLooksSafe now also inspects id and rejects
+    // popup-toggles (aria-haspopup/aria-expanded), so a wrong click (mic, attach,
+    // model-picker, "+") is filtered here too — worse than no click at all.
+    if (!_sendLooksSafe(el)) continue;
     /* v8.1 semantic gate: proximity + an svg icon must NEVER be enough on
        their own (that combination is every message-action button on the
        page). A candidate needs at least one POSITIVE send signal. */

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.2
+// @version      8.1.3
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -52,7 +52,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.2';
+const VER = '8.1.3';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -295,11 +295,23 @@ const GITL_NET = {
   install() {
     if (this.active) return;
     this.active = true;
+    /* v8.1.3 field report (Gemini "doesn't load"): install() used to run
+       fully unguarded at module top-level, OUTSIDE safeBoot()'s try/catch
+       (which only wraps panel creation much further down). In strict mode,
+       reassigning a property a host page has hardened (Object.defineProperty
+       with writable:false — a real pattern on security-conscious Google
+       properties) throws a TypeError right here, which aborts the ENTIRE
+       script before a single line of panel code runs: no #gitl, no console
+       message a normal user would ever see, nothing. Every patch below is
+       now individually fault-tolerant, and the whole method is wrapped too,
+       so one hardened site can only cost that site's network telemetry —
+       never the panel. */
+    try {
 
     /* Fetch proxy on the PAGE window — captures SSE / JSON streams */
     const self = this;
-    const origFetch = UW.fetch;
-    if (typeof origFetch === 'function') UW.fetch = async function(...args) {
+    let origFetch; try { origFetch = UW.fetch; } catch(_) { origFetch = null; }
+    try { if (typeof origFetch === 'function') UW.fetch = async function(...args) {
       const response = await origFetch.apply(this, args);
       const listed = self._isChat(args[0]);
       let heur = false;
@@ -354,33 +366,35 @@ const GITL_NET = {
         }
       }
       return response;
-    };
+    }; } catch(err) { console.warn('[GITL] fetch patch skipped:', err); }
 
     /* XHR proxy on the PAGE window — Gemini streams via batchexecute XHRs */
-    const XP = (UW.XMLHttpRequest && UW.XMLHttpRequest.prototype) || null;
-    if (XP && XP.open && XP.send) {
-      const origOpen = XP.open;
-      XP.open = function(method, url, ...rest) {
-        this._gitlUrl = url; this._gitlMethod = method;
-        return origOpen.call(this, method, url, ...rest);
-      };
-      const origSend = XP.send;
-      XP.send = function(...args) {
-        const listed = self._isChat(this._gitlUrl);
-        const heur = !listed && self._maybeChat(this._gitlUrl, this._gitlMethod);
-        if (listed || heur) {
-          try {
-            this.addEventListener('loadstart', () => { self._open++; self._pulse(listed); });
-            this.addEventListener('progress',  () => self._pulse(listed));
-            this.addEventListener('loadend',   () => { self._open = Math.max(0, self._open - 1); self._pulse(listed); });
-            if (listed) this.addEventListener('load', function() {
-              if (this.status >= 200 && this.status < 300 && this.responseText) self._emit(this.responseText, true);
-            });
-          } catch(_) {}
-        }
-        return origSend.apply(this, args);
-      };
-    }
+    try {
+      const XP = (UW.XMLHttpRequest && UW.XMLHttpRequest.prototype) || null;
+      if (XP && XP.open && XP.send) {
+        const origOpen = XP.open;
+        XP.open = function(method, url, ...rest) {
+          this._gitlUrl = url; this._gitlMethod = method;
+          return origOpen.call(this, method, url, ...rest);
+        };
+        const origSend = XP.send;
+        XP.send = function(...args) {
+          const listed = self._isChat(this._gitlUrl);
+          const heur = !listed && self._maybeChat(this._gitlUrl, this._gitlMethod);
+          if (listed || heur) {
+            try {
+              this.addEventListener('loadstart', () => { self._open++; self._pulse(listed); });
+              this.addEventListener('progress',  () => self._pulse(listed));
+              this.addEventListener('loadend',   () => { self._open = Math.max(0, self._open - 1); self._pulse(listed); });
+              if (listed) this.addEventListener('load', function() {
+                if (this.status >= 200 && this.status < 300 && this.responseText) self._emit(this.responseText, true);
+              });
+            } catch(_) {}
+          }
+          return origSend.apply(this, args);
+        };
+      }
+    } catch(err) { console.warn('[GITL] XHR patch skipped:', err); }
 
     /* WebSocket pulse — Perplexity's socket.io traffic (timestamps only) */
     try {
@@ -393,14 +407,20 @@ const GITL_NET = {
           }
         });
       }
-    } catch(_) {}
+    } catch(err) { console.warn('[GITL] WebSocket patch skipped:', err); }
 
     console.log('[GITL] Network interceptor active');
+    } catch(err) {
+      console.error('[GITL] Network interceptor failed to install — panel will still boot:', err);
+      try { GM_setValue('lastNetInstallError', JSON.stringify({ msg: String(err?.message||err), at: new Date().toISOString() })); } catch(_) {}
+    }
   }
 };
 
-/* Install immediately — safe even before DOM */
-GITL_NET.install();
+/* Install immediately — safe even before DOM. Also guarded at the call site:
+   this runs before safeBoot() and used to be able to take the whole script
+   down with it (see the v8.1.3 note inside install()). */
+try { GITL_NET.install(); } catch(err) { console.error('[GITL] GITL_NET.install() threw at top level — continuing boot anyway:', err); }
 
 /* ═══════════════════════════════════════════════════════════════
    LAYER 1 — PLATFORM ADAPTERS (all DOM access lives here)
@@ -4491,5 +4511,19 @@ safeBoot(() => {
   }, 2000);
   Timeline.record('boot', { version: VER, platform: PLAT.label, tab: GITL_TAB_ID.slice(0,8) });
   console.log(`[Ghost in the Loop v${VER}] ${PLAT.label} | ${DIAG.adapter} | tab:${GITL_TAB_ID.slice(0,8)}`);
+
+  /* v8.1.3: surface a PRIOR boot failure once, instead of it living silently
+     in GM storage forever. Reaching this line means boot succeeded THIS
+     time (the panel you're looking at is proof), so this only fires for a
+     failure on an earlier page load — e.g. a hardened page killed the whole
+     script before install() was made fault-tolerant. Visible in the
+     Diagnostics probe / any auto-report from here on, then cleared so it
+     doesn't repeat every boot. */
+  try {
+    const lastBoot = GM_getValue('lastBootError', '');
+    const lastNet  = GM_getValue('lastNetInstallError', '');
+    if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
+    if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
+  } catch(_) {}
 });
 })();

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.0
+// @version      8.1.1
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -52,7 +52,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.0';
+const VER = '8.1.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.4
+// @version      8.1.5
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -94,10 +94,41 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.4';
+const VER = '8.1.5';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
+
+/* ═══════════════════════════════════════════════════════════════
+   TRUSTED TYPES (v8.1.5) — the actual Gemini root cause
+   Gemini (a Google property) enforces `require-trusted-types-for 'script'`.
+   Under that CSP, assigning a plain string to `.innerHTML` THROWS
+   ("Sink type mismatch violation blocked by CSP" in Firefox) — which killed
+   boot on the very first render and is why the panel never appeared on
+   Gemini specifically (no other supported platform enforces Trusted Types).
+   Confirmed from the v8.1.4 fail-loud banner on the reporter's device.
+   Fix: register one policy at boot and route GITL's 4 innerHTML sinks through
+   it. On every site that does NOT enforce Trusted Types, `_ttPolicy` stays
+   null and `_TT()` returns the raw string — byte-identical behaviour, zero
+   regression risk off Gemini. GITL only ever passes its OWN static templates
+   here (persona/workflow text is already escaped via _esc upstream), so the
+   pass-through policy introduces no new injection surface. */
+let _ttPolicy = null;
+try {
+  if (typeof window !== 'undefined' && window.trustedTypes && window.trustedTypes.createPolicy) {
+    // A per-script named policy — page-scoped, does NOT touch the page's own
+    // default policy or other code. Name kept unique to avoid collisions.
+    _ttPolicy = window.trustedTypes.createPolicy('gitl-ui', { createHTML: (s) => s });
+  }
+} catch (e) {
+  // A restrictive `trusted-types` allow-list can forbid creating our policy.
+  // Record it (surfaces via the beacon/banner) — the panel would then need a
+  // DOM-built fallback, tracked as follow-up. Never fatal here.
+  _ttPolicy = null;
+  try { _beacon('tt-policy-blocked'); } catch(_) {}
+}
+/* Wrap any HTML string destined for an innerHTML sink. */
+function _TT(s) { return _ttPolicy ? _ttPolicy.createHTML(s) : s; }
 const SIGIL_PROCEED = '[[GITL::PROCEED]]';
 const SIGIL_HALT    = '[[GITL::HALT]]';
 const LEGACY_PROCEED = 'PROCEED';
@@ -2618,7 +2649,7 @@ const VEIL = {
     // immune to z-index wars and transform-based parents. Feature-detected.
     this._popover = typeof this.el.showPopover === 'function';
     if (this._popover) { try { this.el.setAttribute('popover', 'manual'); } catch(_) { this._popover = false; } }
-    this.el.innerHTML = `
+    this.el.innerHTML = _TT(`
       <div class="gv-card">
         <div class="gv-ringwrap">
           <div class="gv-ghost-x gv-gx1">👻</div>
@@ -2633,7 +2664,7 @@ const VEIL = {
         <div class="gv-pct" id="gv-pct"></div>
         <div class="gv-note" id="gv-note">Please don't reload the page</div>
         <button class="gv-cancel" id="gv-cancel">Cancel</button>
-      </div>`;
+      </div>`);
     document.body.appendChild(this.el);
     this.el.querySelector('#gv-cancel').addEventListener('click', () => { this.cancelled = true; this.el.querySelector('#gv-title').textContent = 'Stopping…'; });
     // Re-assert top-layer if the tab was backgrounded (mobile browsers can drop
@@ -2691,8 +2722,8 @@ const VEIL = {
     this.renderSteps(); this.beat(null);
   },
   renderSteps() {
-    this.el.querySelector('#gv-steps').innerHTML = this.steps.map((s, i) =>
-      `<div class="gv-step${i < this.idx ? ' done' : i === this.idx ? ' act' : ''}">${i < this.idx ? '✓' : i === this.idx ? '▶' : '·'} ${s}</div>`).join('');
+    this.el.querySelector('#gv-steps').innerHTML = _TT(this.steps.map((s, i) =>
+      `<div class="gv-step${i < this.idx ? ' done' : i === this.idx ? ' act' : ''}">${i < this.idx ? '✓' : i === this.idx ? '▶' : '·'} ${s}</div>`).join(''));
   },
   beat(pct) {
     this.lastBeat = Date.now();
@@ -3730,7 +3761,7 @@ function _explainLookup(target) {
 function _explainShow(info) {
   let tip = panel.querySelector('.g-xtip');
   if (!tip) { tip = document.createElement('div'); tip.className = 'g-xtip'; panel.appendChild(tip); }
-  tip.innerHTML = `<span class="x" id="g-xtip-x">✕</span><b>${info.name}</b><br>${info.desc}`;
+  tip.innerHTML = _TT(`<span class="x" id="g-xtip-x">✕</span><b>${info.name}</b><br>${info.desc}`);
 }
 function _explainIntercept(e) {
   const t = e.target;
@@ -4190,7 +4221,7 @@ function render() {
       : '';
     return [bar, line1, line2].filter(Boolean).join('');
   })();
-  panel.innerHTML = `
+  panel.innerHTML = _TT(`
     <div class="g-hdr" id="g-drag">
       <span class="g-logo">${col && GHOST.ui.position==='dock-left' ? '☰ Ghost' : '<span class="g-ghost">👻</span> Ghost'}<span class="g-dot ${dotClass()}"></span></span>
       <span style="display:flex;align-items:center;gap:5px">
@@ -4225,7 +4256,7 @@ function render() {
         ${tab==='personas'?renderPersonasTab():''}${tab==='export'?renderExportTab():''}
         ${tab==='settings'?renderSettingsTab():''}
       </div>
-    </div>`;
+    </div>`);
   bindEvents();
   applyPosition(GHOST.ui.position);
 }

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.0.0.13
+// @version      8.1.0
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -52,7 +52,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.0.0.13';
+const VER = '8.1.0';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -608,7 +608,23 @@ function _qAll(sels) {
    the Playwright-style aria/text-first strategy. Engaged only when the
    selector arrays come up empty, so normal operation is unchanged. */
 const SEND_WORDS = /send|submit|发送|傳送|送信|보내기|enviar|envoyer|senden|invia|отправ|إرسال|gönder/i;
-const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close/i;
+/* v8.1: veto list expanded after the DeepSeek incident — the heuristic tier
+   clicked the reply's "Copy" button (svg icon + proximity alone scored past
+   the old threshold) and the user's prompt got copied instead of sent.
+   Message-action verbs are now hard-vetoed on EVERY send tier. */
+const SEND_VETO  = /stop|voice|mic|dictat|attach|upload|search|new chat|settings|menu|close|copy|download|share|edit|delete|regenerat|retry|rewrite|like|dislike|thumb|feedback|read.?aloud|speaker|volume|translat|pin\b|bookmark|history|sidebar|scroll|expand|collapse|fullscreen|deep.?think|research/i;
+
+/* A candidate send control must clear the veto no matter which tier found
+   it — configured selectors can rot into matching the wrong control after
+   a site redesign (e.g. div[class*="send"] matching a share widget). */
+function _sendLooksSafe(el) {
+  if (!el) return false;
+  try {
+    const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
+                   el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
+    return !SEND_VETO.test(label);
+  } catch(_) { return true; }
+}
 
 function _visible(el) {
   try {
@@ -654,6 +670,13 @@ function _heurSend(anchor) {
     const label = [el.getAttribute('aria-label'), el.getAttribute('title'),
                    el.getAttribute('data-testid'), el.textContent].join(' ').slice(0, 120);
     if (SEND_VETO.test(label)) continue; // hard veto — a wrong click (mic, attach) is worse than no click
+    /* v8.1 semantic gate: proximity + an svg icon must NEVER be enough on
+       their own (that combination is every message-action button on the
+       page). A candidate needs at least one POSITIVE send signal. */
+    const sem = SEND_WORDS.test(label)
+             || (el.getAttribute('type') || '') === 'submit'
+             || (aForm && el.closest && el.closest('form') === aForm);
+    if (!sem) continue;
     let s = 0;
     if (SEND_WORDS.test(label)) s += 4;
     if ((el.getAttribute('type') || '') === 'submit') s += 2;
@@ -671,10 +694,110 @@ function _heurSend(anchor) {
   return best;
 }
 
+/* ── SELECTOR MEMORY (v8.1) — self-healing learned locators ──────
+   Healenium-style: when the configured selectors fail but the heuristic
+   tier finds the element, derive a STABLE selector from the found node
+   (id > data-testid > aria-label > name > placeholder > role) and persist
+   it per-host. Next time — including after a reload — the learned selector
+   is tried right after the configured ones, so a site redesign pays the
+   heuristic cost once and the fix survives sessions. Capped + self-pruning. */
+const SelectorMemory = {
+  key: 'gitlLearnedSelectors',
+  MAX_HOSTS: 12,
+  _data: null,
+
+  _load() {
+    if (this._data) return this._data;
+    try { this._data = JSON.parse(GM_getValue(this.key, '{}')) || {}; } catch(_) { this._data = {}; }
+    return this._data;
+  },
+  _persist() { try { GM_setValue(this.key, JSON.stringify(this._data)); } catch(_){} },
+
+  /* Derive a stable selector that uniquely matches el right now, or null. */
+  derive(el) {
+    if (!el || !el.getAttribute) return null;
+    const esc = (s) => (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(s) : String(s).replace(/([^\w-])/g, '\\$1');
+    const tag = (el.tagName || '').toLowerCase();
+    const cands = [];
+    const id = el.getAttribute('id');
+    if (id) cands.push(`#${esc(id)}`);
+    for (const a of ['data-testid','data-test-id','aria-label','name','placeholder','data-placeholder']) {
+      const v = el.getAttribute(a);
+      if (v && v.length <= 80) cands.push(`${tag}[${a}="${v.replace(/\\/g,'\\\\').replace(/"/g,'\\"')}"]`);
+    }
+    const role = el.getAttribute('role');
+    if (role && el.getAttribute('contenteditable') === 'true') cands.push(`${tag}[contenteditable="true"][role="${role}"]`);
+    for (const sel of cands) {
+      try { const m = document.querySelectorAll(sel); if (m.length === 1 && m[0] === el) return sel; } catch(_){}
+    }
+    return null;
+  },
+
+  learn(kind, el) {
+    const sel = this.derive(el);
+    if (!sel) return null;
+    const d = this._load(), h = location.hostname;
+    d[h] = d[h] || {};
+    const prev = d[h][kind];
+    d[h][kind] = { sel, at: Date.now() };
+    // Prune least-recently-touched hosts beyond the cap.
+    const hosts = Object.keys(d);
+    if (hosts.length > this.MAX_HOSTS) {
+      hosts.sort((a, b) =>
+        Math.max(0, ...Object.values(d[a]).map(x => x.at || 0)) -
+        Math.max(0, ...Object.values(d[b]).map(x => x.at || 0)));
+      while (hosts.length > this.MAX_HOSTS) delete d[hosts.shift()];
+    }
+    this._persist();
+    if (!prev || prev.sel !== sel) {
+      try { DIAG.push(`Learned ${kind} selector: ${sel}`); } catch(_){}
+      try { Timeline.record('selector_learned', { kind, sel }); } catch(_){}
+    }
+    return sel;
+  },
+
+  lookup(kind) {
+    const rec = this._load()[location.hostname]?.[kind];
+    if (!rec || !rec.sel) return null;
+    try {
+      for (const el of document.querySelectorAll(rec.sel)) {
+        if (el && !_isOwnUI(el) && _visible(el)) {
+          if (kind === 'send' && !_sendLooksSafe(el)) { this.forget(kind); return null; }
+          return el;
+        }
+      }
+    } catch(_) { this.forget(kind); }
+    return null;
+  },
+
+  forget(kind) {
+    const d = this._load(), h = location.hostname;
+    if (d[h] && d[h][kind]) {
+      delete d[h][kind];
+      if (!Object.keys(d[h]).length) delete d[h];
+      this._persist();
+    }
+  }
+};
+
 // Adapter — all DOM reads/writes
 const Adapter = {
-  getInput()      { return _q('in', PLAT.input) || _heurInput(); },
-  getSendBtn()    { const b = _q('send', PLAT.send); return (b && !b.disabled) ? b : (_heurSend(_q('in', PLAT.input) || null) || b); },
+  getInput() {
+    let el = _q('in', PLAT.input) || SelectorMemory.lookup('input');
+    if (!el) { el = _heurInput(); if (el) SelectorMemory.learn('input', el); }
+    return el;
+  },
+  getSendBtn() {
+    // Every tier passes through the veto — a stale configured selector must
+    // never hand back a Copy/Share/Download control (DeepSeek incident).
+    const b = _q('send', PLAT.send);
+    if (b && !b.disabled && _sendLooksSafe(b)) return b;
+    const learned = SelectorMemory.lookup('send');
+    if (learned && !learned.disabled) return learned;
+    const h = _heurSend(this.getInput() || null);
+    if (h) { SelectorMemory.learn('send', h); return h; }
+    return (b && _sendLooksSafe(b)) ? b : null;
+  },
   isGenerating()  { return !!_q('gen', PLAT.stop) || GITL_NET.streaming(); },
   hasMessages()   { return _qAll(PLAT.assistant).length > 0; },
   getLastText() {
@@ -907,14 +1030,44 @@ const Workshop = {
 
   // ── Export: combined bundle of custom items only ──
   exportBundle() {
-    return JSON.stringify({
+    const out = {
       schema: WORKSHOP_SCHEMA,
       tool: 'Ghost in the Loop',
       version: VER,
       exported: new Date().toISOString(),
       personas:  Object.entries(this.personas).map(([id,p])  => ({ id, label: p.label, inject: p.inject })),
       workflows: Object.entries(this.workflows).map(([id,w]) => ({ id, label: w.label, desc: w.desc, stages: w.stages }))
-    }, null, 2);
+    };
+    // v8.1: the active custom skin rides along (validated tokens only), so a
+    // single .gitl.json can share a complete look-and-brains pack.
+    try {
+      if (typeof SKIN !== 'undefined' && typeof GHOST !== 'undefined'
+          && GHOST.ui.skinTheme === 'custom' && GHOST.ui.customSkin) {
+        const r = SKIN.validate(GHOST.ui.customSkin);
+        if (r.ok) out.skin = r.skin;
+      }
+    } catch(_) {}
+    return JSON.stringify(out, null, 2);
+  },
+
+  // ── Share (v8.1): paste-ready markdown post for GitHub Discussions ──
+  shareText() {
+    const nP = Object.keys(this.personas).length;
+    const nW = Object.keys(this.workflows).length;
+    const items = [
+      ...Object.values(this.personas).map(p => `- 👤 ${p.label}`),
+      ...Object.values(this.workflows).map(w => `- ⛓ ${w.label} (${(w.stages||[]).length} stages)`)
+    ];
+    let skinLine = '';
+    try {
+      if (typeof GHOST !== 'undefined' && GHOST.ui.skinTheme === 'custom' && GHOST.ui.customSkin) {
+        const nm = JSON.parse(GHOST.ui.customSkin).name || 'custom';
+        items.push(`- 🎨 Skin: ${nm}`);
+        skinLine = ', 1 skin';
+      }
+    } catch(_) {}
+    const title = (typeof GHOST !== 'undefined' && GHOST.project.name) ? GHOST.project.name : 'My GITL pack';
+    return `## Workshop pack: ${title}\n\n**Contains:** ${nP} persona(s), ${nW} workflow(s)${skinLine}\n\n${items.join('\n')}\n\nTo use: save the JSON below as \`pack.gitl.json\`, then **⬆ Import** in Ghost's Workshop.\n\n\`\`\`json\n${this.exportBundle()}\n\`\`\`\n`;
   },
 
   // ── Import: additive, protects built-ins, auto-renames custom clashes ──
@@ -927,7 +1080,8 @@ const Workshop = {
     if (data.schema && !String(data.schema).startsWith('gitl-workshop/')) return { ok:false, error:'Not a Ghost Workshop file' };
     const inP = Array.isArray(data.personas)  ? data.personas  : [];
     const inW = Array.isArray(data.workflows) ? data.workflows : [];
-    if (inP.length + inW.length === 0) return { ok:false, error:'No personas or workflows in file' };
+    const hasSkin = data.skin && typeof data.skin === 'object';
+    if (inP.length + inW.length === 0 && !hasSkin) return { ok:false, error:'No personas, workflows, or skin in file' };
     if (inP.length + inW.length > WORKSHOP_LIMITS.maxItems) return { ok:false, error:`Too many items (max ${WORKSHOP_LIMITS.maxItems})` };
     const res = { ok:true, personas:0, workflows:0, skipped:0, renamed:0 };
     const pTaken = new Set([...Object.keys(PERSONA_LIBRARY), ...Object.keys(this.personas)]);
@@ -950,6 +1104,24 @@ const Workshop = {
       this.workflows[id] = { label: w.label.trim().slice(0,WORKSHOP_LIMITS.label), desc: String(w.desc||'').trim().slice(0,WORKSHOP_LIMITS.desc),
         stages: w.stages.map(s => String(s).trim().slice(0,WORKSHOP_LIMITS.stage)).slice(0,WORKSHOP_LIMITS.stages), custom: true };
       res.workflows++;
+    }
+    // v8.1: optional bundled skin — validated by the skin whitelist, applied
+    // as the custom skin. Invalid skins are skipped, never fatal.
+    res.skin = 0;
+    if (hasSkin) {
+      try {
+        if (typeof SKIN !== 'undefined') {
+          const r = SKIN.validate(JSON.stringify(data.skin));
+          if (r.ok && typeof GHOST !== 'undefined') {
+            GHOST.ui.customSkin = JSON.stringify(r.skin);
+            GHOST.ui.skinTheme = 'custom';
+            _save('customSkin', GHOST.ui.customSkin);
+            _save('skinTheme', 'custom');
+            SKIN.apply();
+            res.skin = 1;
+          } else { res.skipped++; }
+        }
+      } catch(_) { res.skipped++; }
     }
     this._persist();
     return res;
@@ -1076,6 +1248,16 @@ const DIAG = {
       }
       out.push(n ? `✓ ${k}: ${win} (${n})` : `✗ ${k}: NO MATCH`);
     }
+    // Fallback tiers (v8.1): learned per-host selectors, then role/meaning heuristics.
+    try {
+      const lm = (typeof SelectorMemory !== 'undefined') ? SelectorMemory._load()[location.hostname] : null;
+      out.push(lm ? `✓ learned: ${Object.entries(lm).map(([k,v]) => k + '=' + v.sel).join(' · ')}` : '— learned: none for this host');
+    } catch(_) {}
+    try {
+      const hi = _heurInput(), hs = _heurSend(hi || null);
+      out.push(hi ? `✓ heur input: <${(hi.tagName||'?').toLowerCase()}>` : '✗ heur input: none');
+      out.push(hs ? `✓ heur send: <${(hs.tagName||'?').toLowerCase()}> "${String(hs.getAttribute && (hs.getAttribute('aria-label')||hs.textContent)||'').trim().slice(0,30)}"` : '✗ heur send: none');
+    } catch(_) {}
     this.probe = out.join('\n');
   }
 };
@@ -1146,7 +1328,7 @@ const Timeline = {
    ═══════════════════════════════════════════════════════════════ */
 const Reporter = {
   last: null,         // most recent assembled report {kind, detail, text, at}
-  _seen: new Set(),   // dedupe identical auto-captures within a session
+  _seen: new Map(),   // dedupe: signature -> last capture ts (10-min window)
 
   build(kind, detail) {
     const L = (typeof GHOST !== 'undefined') ? GHOST.loop : {};
@@ -1171,6 +1353,10 @@ const Reporter = {
     lines.push(`| Send path | ${DIAG?.sendPath || 'n/a'} |`);
     lines.push(`| Health | ${h.badge || ''} ${h.score ?? '?'}/100 (in:${h.input} send:${h.send} stop:${h.stop} msgs:${h.assistantCount}) |`);
     lines.push(`| Net intercept | ${h.netActive ? 'active' : 'off'} |`);
+    try {
+      const lm = (typeof SelectorMemory !== 'undefined') ? SelectorMemory._load()[location.hostname] : null;
+      lines.push(`| Learned selectors | ${lm ? Object.entries(lm).map(([k,v]) => k + ': ' + v.sel).join(' · ') : 'none'} |`);
+    } catch(_) {}
     lines.push(`| Focus | hasFocus:${typeof document!=='undefined'?document.hasFocus():'?'} hidden:${typeof document!=='undefined'?document.hidden:'?'} |`);
     lines.push(`| Unattended | ${unattendedOn()?'ON':'off'} · ticker:${Ticker.mode} |`);
     lines.push(`| UA | ${typeof navigator!=='undefined'?navigator.userAgent:'?'} |`);
@@ -1185,6 +1371,12 @@ const Reporter = {
 
   // Auto-capture: assemble + store + surface a non-intrusive affordance.
   capture(kind, detail) {
+    // Dedupe: the same failure re-captured within 10 min just refreshes
+    // the timestamp instead of rebuilding + re-sending a duplicate.
+    const sig = kind + '|' + String(detail || '').slice(0, 120);
+    const seenAt = this._seen.get(sig) || 0;
+    this._seen.set(sig, Date.now());
+    if (this.last && Date.now() - seenAt < 600000) return this.last;
     const text = this.build(kind, detail);
     this.last = { kind, detail, text, at: Date.now() };
     if (typeof GHOST !== 'undefined') GHOST.report = this.last;
@@ -1838,6 +2030,7 @@ function engineTick() {
 
   if (result.signal === 'halt') {
     L.staleTicks = 0;
+    L.noSigilStreak = 0; L._nudgedTail = '';
     // Workflow auto-advance
     if (GHOST.workflow.active && GHOST.workflow.autoAdvance) {
       const wf = allWorkflows()[GHOST.workflow.selected] || WORKFLOW_LIBRARY.none;
@@ -1877,6 +2070,7 @@ function engineTick() {
 
   if (result.signal === 'proceed') {
     L.staleTicks = 0;
+    L.noSigilStreak = 0; L._nudgedTail = '';
     if (L.payloadMode === 'roadmap') {
       const R = GHOST.roadmap;
       if (!R.captured) {
@@ -1886,7 +2080,7 @@ function engineTick() {
           // common with custom GPTs that self-track "[Step X of Y]". Ask once for just the block.
           R._reask = true;
           L.detail = '🗺 No roadmap block — re-requesting format (1 auto-retry)…';
-          Timeline.add('roadmap_reask', { round: L.round });
+          Timeline.record('roadmap_reask', { round: L.round });
           engineSend('No [[GITL::ROADMAP]] block was detected in your last response. Do NOT redo the research or execute anything. Output ONLY the roadmap now, in exactly this format:\n\n[[GITL::ROADMAP]]\n1. first concrete step\n2. second concrete step\n3. ...\n\n(3–12 steps, each self-contained) End with [[GITL::PROCEED]]', false);
           render();
         }
@@ -1924,7 +2118,29 @@ function engineTick() {
   L._thinkNoted = false;
   L.staleTicks++;
   const staleLimit = (PLAT && PLAT.staleTicks) || 5;
-  if (L.staleTicks >= staleLimit) enginePause('No signal detected — review output');
+  if (L.staleTicks >= staleLimit) {
+    /* v8.1 sigil-free completion fallback: some models (DeepSeek especially)
+       answer fully but never echo the [[GITL::…]] protocol markers. The reply
+       IS complete — generation ended and the text went quiet — so instead of
+       stranding the run, auto-continue once with a protocol reminder. Only
+       after two consecutive sigil-free replies do we pause for review. Every
+       nudge still consumes a round, so drift guard / round limit keep their
+       grip on runaway loops. */
+    const tail = text.slice(-200);
+    if (tail === L._nudgedTail && (L.isSending || L.sendPending)) return; // nudge already in flight
+    if (!L.isSending && !L.sendPending && text.length > 20 && (L.noSigilStreak || 0) < 2 && tail !== L._nudgedTail) {
+      L.noSigilStreak = (L.noSigilStreak || 0) + 1;
+      L._nudgedTail = tail;
+      L.staleTicks = 0;
+      L.detail = `🕯 Reply had no sigil — auto-continuing (${L.noSigilStreak}/2) + re-stating protocol`;
+      DIAG.push(`Sigil missing — soft proceed (${L.noSigilStreak}/2)`);
+      Timeline.record('soft_proceed', { streak: L.noSigilStreak, round: L.round });
+      engineSend('Continue.\n\n[Ghost protocol reminder — your last reply was missing the control marker. From now on END EVERY reply with exactly one of:\n[[GITL::PROCEED]] — more work remains\n[[GITL::HALT]] — the whole task is fully complete\nAlso include "[Step X of Y]" on its own line so progress can be tracked.]', false);
+      render();
+      return;
+    }
+    enginePause('No sigil after 2 auto-continues — review output (the model may be ignoring the protocol)');
+  }
 }
 
 // Watchdog heartbeat (supplements tick)
@@ -2077,21 +2293,87 @@ window.addEventListener('popstate', () => window.dispatchEvent(new Event('gitl:r
 window.addEventListener('gitl:route', () => {
   if (location.href !== _lastHref) {
     _lastHref = location.href;
-    _cache.clear();
+    _clearElementCaches();
     if (GHOST.loop.state === 'RUNNING') enginePause('Route changed — paused');
   }
 });
 
-/* Manual re-detect (v7.1): force a clean re-resolution of the page's
-   chat input / send button. Fixes the case where you move browser → app →
-   back into the same chat: the URL is unchanged so the route-watcher never
-   fired, but the SPA rebuilt the DOM and Ghost is holding stale/detached
-   element references (or the shadow-walk throttle is blocking a re-scan).
-   This clears every cache, re-resolves the platform, and re-probes —
-   no page reload, no hopping between chats. */
-function reDetect() {
+/* One place that forgets every cached element reference — the route watcher,
+   reDetect, and the visibility healer all funnel through here so no cache
+   (selector, shadow-walk throttle, heuristic) can be missed again. */
+function _clearElementCaches() {
   _cache.clear();
   _deepLast.clear();
+  _heurCache.input = { el: null, ts: 0 };
+  _heurCache.send  = { el: null, ts: 0 };
+}
+
+/* Silent self-heal (v8.1): coming back from another app/tab is exactly when
+   the SPA has rebuilt its DOM underneath us. If our cached composer is now a
+   detached node, drop the caches so the next lookup re-resolves — no UI
+   noise, no user action needed. This removes most manual 🔄 presses. */
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') return;
+  const c = _cache.get('in');
+  if (c && !c.isConnected) _clearElementCaches();
+});
+
+/* Manual re-detect (v7.1, hardened v8.1): force a clean re-resolution of the
+   page's chat input / send button. Fixes the case where you move browser →
+   app → back into the same chat: the URL is unchanged so the route-watcher
+   never fired, but the SPA rebuilt the DOM and Ghost is holding stale nodes.
+   v8.1: no longer one-shot. If the first pass misses (SPA mid-remount — the
+   exact moment users press 🔄), a MutationObserver + interval keeps watching
+   for up to 12s and reports success the moment the composer appears. */
+const _redetectWatch = { obs: null, timer: null, deadline: 0, nudged: false };
+
+function _redetectStop() {
+  try { _redetectWatch.obs?.disconnect(); } catch(_){}
+  if (_redetectWatch.timer) clearInterval(_redetectWatch.timer);
+  _redetectWatch.obs = null; _redetectWatch.timer = null; _redetectWatch.deadline = 0;
+  try { document.querySelector('#g-redetect')?.classList.remove('spin'); } catch(_){}
+}
+
+function _redetectCheck() {
+  const input = Adapter.getInput();
+  if (input) {
+    _redetectStop();
+    try { DIAG.runProbe(); } catch(_){}
+    Timeline.record('redetect_late', { platform: PLAT?.label });
+    GHOST.loop.detail = `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`;
+    render();
+    return true;
+  }
+  if (Date.now() > _redetectWatch.deadline) {
+    _redetectStop();
+    Timeline.record('redetect_timeout', { platform: PLAT?.label });
+    GHOST.loop.detail = '🔄 Still no chat input after 12s. Tap inside the chat box once, then 🔄 again.';
+    render();
+    return false;
+  }
+  // Focus nudge (once): some editors only mount their real composer on focus.
+  // Never steal focus from the user — only when nothing meaningful is focused.
+  if (!_redetectWatch.nudged && Date.now() > _redetectWatch.deadline - 9000) {
+    _redetectWatch.nudged = true;
+    try {
+      const ae = document.activeElement;
+      if (!ae || ae === document.body) {
+        for (const el of _qAll(['textarea:not([disabled])','div[contenteditable="true"]'])) {
+          if (_visible(el)) { el.focus(); break; }
+        }
+      }
+    } catch(_){}
+  }
+  return false;
+}
+
+function reDetect() {
+  _redetectStop();
+  _clearElementCaches();
+  // Abandoned streams from a background hop can leave stale counters that
+  // fake "still generating" — zero the network expectation state too.
+  GITL_NET._open = 0;
+  GITL_NET.expectUntil = 0;
   // Re-resolve platform in case the host changed (e.g. app vs web shell).
   let matched = null;
   for (const [, p] of Object.entries(PROFILES)) { if (p.host.test(location.hostname)) { matched = p; break; } }
@@ -2101,12 +2383,27 @@ function reDetect() {
   const send  = Adapter.getSendBtn();
   try { DIAG.runProbe(); } catch(_){}
   Timeline.record('redetect', { found_input: !!input, found_send: !!send, platform: PLAT?.label });
-  const ok = !!input;
-  GHOST.loop.detail = ok
-    ? `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`
-    : '🔄 Re-detected — still no chat input. Try clicking inside the chat box once, then re-detect.';
+  if (input) {
+    GHOST.loop.detail = `🔄 Re-detected ✓ — found chat input on ${PLAT?.label || 'page'}`;
+    render();
+    return true;
+  }
+  // Not found yet — keep watching. SPAs often remount the composer a beat
+  // after the user notices it's "gone" and presses 🔄.
+  GHOST.loop.detail = '🔄 Searching for the chat box…';
   render();
-  return ok;
+  try { document.querySelector('#g-redetect')?.classList.add('spin'); } catch(_){}
+  _redetectWatch.deadline = Date.now() + 12000;
+  _redetectWatch.nudged = false;
+  try {
+    _redetectWatch.obs = new MutationObserver(() => {
+      if (_redetectWatch._raf) return; // throttle bursts to one check per frame-ish
+      _redetectWatch._raf = setTimeout(() => { _redetectWatch._raf = null; _redetectCheck(); }, 250);
+    });
+    _redetectWatch.obs.observe(document.body, { childList: true, subtree: true });
+  } catch(_){}
+  _redetectWatch.timer = setInterval(_redetectCheck, 800);
+  return false;
 }
 
 /* ═══════════════════════════════════════════════════════════════
@@ -3982,7 +4279,17 @@ function bindEvents() {
   });
   $('#ws-import')?.addEventListener('click', workshopImport);
   $('#ws-export')?.addEventListener('click', workshopExport);
-  $('#ws-submit')?.addEventListener('click', () => { GHOST.ui.prevTab = GHOST.ui.tab; GHOST.ui.helpSec = 'workshop'; GHOST.ui.tab = 'info'; render(); });
+  $('#ws-submit')?.addEventListener('click', () => {
+    // v8.1: Share now does the work — a paste-ready Discussions post (item
+    // list + JSON bundle) lands on the clipboard, then the how-to opens.
+    try {
+      const t = Workshop.shareText();
+      if (typeof GM_setClipboard === 'function') GM_setClipboard(t, { type:'text', mimetype:'text/plain' });
+      else navigator.clipboard?.writeText(t);
+      GHOST.loop.detail = '🌐 Share post copied — paste it into GitHub Discussions';
+    } catch(_) {}
+    GHOST.ui.prevTab = GHOST.ui.tab; GHOST.ui.helpSec = 'workshop'; GHOST.ui.tab = 'info'; render();
+  });
 
   // Export tab
   $('#exp-fmt')?.addEventListener('change', e => { GHOST.export.format=e.target.value; _save('expFormat',e.target.value); render(); });
@@ -4069,7 +4376,9 @@ function bindEvents() {
   $('#g-redetect')?.addEventListener('click', function(){
     this.classList.add('spin');
     const ok = reDetect();
-    setTimeout(() => this.classList.remove('spin'), 600);
+    // Found immediately → brief spin. Otherwise the async watcher keeps the
+    // spin going and clears it itself on success or 12s timeout.
+    if (ok) setTimeout(() => this.classList.remove('spin'), 600);
   });
   $('#g-info')?.addEventListener('click', () => { GHOST.ui.tab = GHOST.ui.tab==='info' ? 'run' : 'info'; render(); });
   $('#g-info-back')?.addEventListener('click', () => { GHOST.ui.tab = GHOST.ui.prevTab || 'run'; GHOST.ui.prevTab = null; render(); });

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.3
+// @version      8.1.4
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -50,9 +50,51 @@ if (window.__GITL_V8__) return;
 window.__GITL_V8__ = true;
 
 /* ═══════════════════════════════════════════════════════════════
+   BOOT BEACON + FAIL-LOUD (v8.1.4)
+   The Gemini "panel never appears" reports were undiagnosable because a
+   silent top-level throw kills the whole script before the panel (which is
+   where all diagnostics live) can mount — so lastBootError was invisible.
+   Two dependency-free instruments that work even when nothing else does:
+     • a beacon written to <html data-gitl-boot="…"> at each phase, so it
+       shows up in a plain SingleFile/"save page" capture: `started` →
+       `ok:<ver>` on success, or `error:<stage>` if boot throws. This turns a
+       static page save into a real diagnosis of whether the script even ran.
+     • _gitlFatal(): on any fatal boot throw, surface it via GM_notification
+       AND a fixed banner injected at documentElement level (not body — body
+       may be the very thing that's missing/hostile), so the user can SEE and
+       screenshot the actual error instead of a blank page.
+   _gitlFatal is declared at IIFE scope (outside the try below) so it is
+   reachable from both the top-level catch and safeBoot's catch. */
+const _beacon = (s) => { try { document.documentElement.setAttribute('data-gitl-boot', s); } catch(_) {} };
+_beacon('started');
+function _gitlFatal(stage, err) {
+  const msg = String((err && (err.message || err)) || 'unknown');
+  const stack = String((err && err.stack) || '');
+  _beacon('error:' + stage);
+  try { GM_setValue('lastBootError', JSON.stringify({ stage, msg, stack, at: new Date().toISOString() })); } catch(_) {}
+  try { console.error('[GITL] FATAL @' + stage + ':', err); } catch(_) {}
+  try { if (typeof GM_notification === 'function') GM_notification({ title: '👻 Ghost failed to load (' + stage + ')', text: msg, timeout: 15000 }); } catch(_) {}
+  try {
+    if (document.getElementById('gitl-fatal')) return;
+    const b = document.createElement('div');
+    b.id = 'gitl-fatal';
+    b.setAttribute('style', 'position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#3a0d12;color:#ffd7dd;font:600 12px/1.4 system-ui,sans-serif;padding:10px 34px 10px 12px;border-bottom:2px solid #ff5570;box-shadow:0 4px 18px rgba(0,0,0,.5);white-space:pre-wrap;word-break:break-word');
+    b.textContent = '👻 Ghost in the Loop couldn’t start on this page (' + stage + ').\n' + msg + '\nScreenshot this and send it — it says exactly what broke.';
+    const x = document.createElement('span');
+    x.textContent = '×';
+    x.setAttribute('style', 'position:absolute;top:6px;right:10px;cursor:pointer;font-size:18px;line-height:1');
+    x.addEventListener('click', () => b.remove());
+    b.appendChild(x);
+    (document.body || document.documentElement).appendChild(b);
+  } catch(_) {}
+}
+
+try {
+
+/* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.3';
+const VER = '8.1.4';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -86,8 +128,9 @@ function safeBoot(fn) {
       if (!document.body) { requestAnimationFrame(boot); return; }
       fn();
     } catch (err) {
-      console.error('[GITL] boot failed:', err);
-      try { GM_setValue('lastBootError', JSON.stringify({ msg: String(err?.message||err), stack: String(err?.stack||''), at: new Date().toISOString() })); } catch(_){}
+      // v8.1.4: was silent (stored to GM only, invisible since the panel that
+      // shows it never mounted). Now fails loud via the same beacon+banner.
+      _gitlFatal('boot', err);
     }
   };
   if (document.readyState === 'loading') {
@@ -4525,5 +4568,37 @@ safeBoot(() => {
     if (lastBoot) { DIAG.push('Previous page load failed to boot: ' + (JSON.parse(lastBoot).msg || lastBoot)); _save('lastBootError', ''); }
     if (lastNet)  { DIAG.push('Previous page load: network interceptor failed to install: ' + (JSON.parse(lastNet).msg || lastNet)); _save('lastNetInstallError', ''); }
   } catch(_) {}
+
+  // Boot completed AND the panel is in the DOM — record success on the beacon.
+  _beacon(document.getElementById('gitl') ? 'ok:' + VER : 'no-panel:' + VER);
+  // Panel self-heal: Gemini's Angular framework (and some other SPAs) can
+  // wipe document.body's children out from under us on route/re-render,
+  // silently removing #gitl with no error thrown — a leading suspect for
+  // "installed and active but nothing shows up" on Gemini specifically.
+  // Watch for the panel disappearing and re-mount it. Cheap: one observer,
+  // only acts when #gitl is actually gone.
+  try { startPanelWatchdog(); } catch(e) { DIAG.push('panel watchdog failed: ' + e); }
 });
+
+/* Re-mounts the panel if the page framework removes it from the DOM. */
+function startPanelWatchdog() {
+  let remounts = 0;
+  const ensure = () => {
+    if (document.getElementById('gitl') || !document.body) return;
+    // Panel vanished — re-append the SAME node (state/handlers intact).
+    _panelMounted = false;
+    mountPanel();
+    remounts++;
+    _beacon('remounted:' + remounts);
+    Timeline.record('panel_remount', { count: remounts });
+    DIAG.push('Panel was removed by the page — re-mounted (#' + remounts + ')');
+    render();
+  };
+  const mo = new MutationObserver(ensure);
+  mo.observe(document.documentElement, { childList: true, subtree: true });
+  // Belt-and-suspenders: a slow poll in case a body swap escapes the observer.
+  setInterval(ensure, 3000);
+}
+
+} catch(__gitlBootErr) { _gitlFatal('top-level', __gitlBootErr); }
 })();

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.1
+// @version      8.1.2
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -52,7 +52,7 @@ window.__GITL_V8__ = true;
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.1';
+const VER = '8.1.2';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled
@@ -2018,7 +2018,20 @@ function engineTick() {
 
   // Read output
   const text = Adapter.getLastText();
-  if (!text) { L.staleTicks++; if (L.staleTicks >= 5) pauseWithProbe('No output detected'); return; }
+  if (!text) {
+    /* v8.1.2 field report (Perplexity Deep Research): this branch fires
+       before the FIRST assistant DOM node exists at all — during a long
+       silent "thinking" phase there is no text to read yet, but net traffic
+       or a stop button proves the model is working. The later no-signal
+       branch already got this isGenerating() witness + per-platform budget
+       in d7; this earlier branch was missed, so slow-starting platforms
+       could still pause ~12s after a perfectly good send. */
+    if (Adapter.isGenerating()) { L.staleTicks = 0; L.detail = '🧠 Model is still working…'; render(); return; }
+    L.staleTicks++;
+    const staleLimit = (PLAT && PLAT.staleTicks) || 5;
+    if (L.staleTicks >= staleLimit) pauseWithProbe('No output detected');
+    return;
+  }
 
   // Detect signal
   const result = detectSignal(text);
@@ -2292,9 +2305,25 @@ function primaryAction() {
 window.addEventListener('popstate', () => window.dispatchEvent(new Event('gitl:route')));
 window.addEventListener('gitl:route', () => {
   if (location.href !== _lastHref) {
+    const prevHref = _lastHref;
     _lastHref = location.href;
     _clearElementCaches();
-    if (GHOST.loop.state === 'RUNNING') enginePause('Route changed — paused');
+    if (GHOST.loop.state === 'RUNNING') {
+      /* v8.1.2 field report (Grok): almost every platform assigns a fresh
+         conversation URL (e.g. "/" -> "/c/<uuid>") the instant the FIRST
+         message is sent — that is normal same-conversation continuation,
+         not navigating away, but it used to pause every run one tick after
+         it started. Only treat it as a real navigation-away when the host
+         changed, or when nothing was sent recently to explain the URL move. */
+      let sameHost = false;
+      try { sameHost = new URL(prevHref).hostname === location.hostname; } catch(_) {}
+      const justSent = GHOST.loop.sendPending || (Date.now() - (GHOST.loop.lastActivity || 0) < 15000);
+      if (sameHost && justSent) {
+        Timeline.record('route_id_assigned', { from: prevHref, to: location.href });
+        return;
+      }
+      enginePause('Route changed — paused');
+    }
   }
 });
 

--- a/dev/ghost-in-the-loop.user.js
+++ b/dev/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.1.5
+// @version      8.2.0
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — Architecture by Claude
 // @match        https://chatgpt.com/*
@@ -101,7 +101,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.1.5';
+const VER = '8.2.0';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop'; // for pre-filled issue URL transport
 const REPORT_WORKER_URL = ''; // set to a relay endpoint to enable silent auto-submit; empty = disabled

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,0 +1,4534 @@
+{
+  "name": "ghost-in-the-loop",
+  "version": "7.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ghost-in-the-loop",
+      "version": "7.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/dev/playwright.config.js
+++ b/dev/playwright.config.js
@@ -1,15 +1,59 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
+const fs = require('fs');
 
 /**
- * Playwright config for Ghost in the Loop boot-timing tests.
+ * Playwright config for Ghost in the Loop e2e.
  *
- * These tests catch the class of bug unit tests CANNOT:
- * script behavior at document-start, when document.head/body are null.
+ * Two engines, on purpose. The Gemini "panel never appears" saga (v8.1.0–8.1.5)
+ * happened because every test ran in Chromium while the field failure was
+ * Firefox Android — so a whole class of engine-specific behaviour (Trusted
+ * Types enforcement, in the end) went unexercised. We now run the suite in
+ * BOTH Chromium and Firefox.
  *
- * Run locally:  npm run test:e2e
- * Run in CI:    same, via .github/workflows/test.yml
+ * Firefox note: Playwright's Firefox is desktop Gecko, not GeckoView/Android.
+ * It is NOT a perfect stand-in for Firefox Android, but it shares the Gecko
+ * engine and the same Trusted Types / CSP implementation, which is exactly the
+ * layer that bit us. Treat Firefox-project passes as "Gecko-validated," not
+ * "Android-certified" — real-device confirmation still belongs to the reporter.
  */
+
+// Managed env pre-installs Chromium at a fixed path; prefer it over a
+// version-pinned download. Firefox is resolved by Playwright from
+// PLAYWRIGHT_BROWSERS_PATH automatically, so it needs no explicit path.
+const chromiumPath = fs.existsSync('/opt/pw-browsers/chromium/chrome-linux/chrome')
+  ? '/opt/pw-browsers/chromium/chrome-linux/chrome'
+  : (fs.existsSync('/opt/pw-browsers/chromium-1194/chrome-linux/chrome')
+    ? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome' : undefined);
+
+// Only advertise the Firefox project if a Firefox build is actually present,
+// so the suite still runs on Chromium-only machines without hard-failing.
+const firefoxAvailable = fs.existsSync('/opt/pw-browsers') &&
+  fs.readdirSync('/opt/pw-browsers').some(d => /^firefox-/.test(d));
+
+const projects = [
+  {
+    name: 'chromium',
+    use: {
+      ...devices['Desktop Chrome'],
+      launchOptions: chromiumPath ? { executablePath: chromiumPath } : {},
+    },
+  },
+];
+
+if (firefoxAvailable) {
+  projects.push({
+    name: 'firefox',
+    use: {
+      ...devices['Desktop Firefox'],
+      // Approximate the reporter's environment (mobile viewport + Android UA)
+      // while keeping the real Gecko engine that enforces Trusted Types.
+      viewport: { width: 412, height: 915 },
+      userAgent: 'Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0',
+    },
+  });
+}
+
 module.exports = defineConfig({
   testDir: './tests/e2e',
   testMatch: '**/*.spec.js',
@@ -21,17 +65,6 @@ module.exports = defineConfig({
     headless: true,
     actionTimeout: 10_000,
     trace: 'retain-on-failure',
-    // Managed environments pre-install chromium at a fixed path; use it if
-    // present instead of downloading a version-pinned browser build.
-    launchOptions: require('fs').existsSync('/opt/pw-browsers/chromium/chrome-linux/chrome')
-      ? { executablePath: '/opt/pw-browsers/chromium/chrome-linux/chrome' }
-      : (require('fs').existsSync('/opt/pw-browsers/chromium-1194/chrome-linux/chrome')
-        ? { executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome' } : {}),
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-  ],
+  projects,
 });

--- a/dev/playwright.config.js
+++ b/dev/playwright.config.js
@@ -28,8 +28,22 @@ const chromiumPath = fs.existsSync('/opt/pw-browsers/chromium/chrome-linux/chrom
 
 // Only advertise the Firefox project if a Firefox build is actually present,
 // so the suite still runs on Chromium-only machines without hard-failing.
-const firefoxAvailable = fs.existsSync('/opt/pw-browsers') &&
-  fs.readdirSync('/opt/pw-browsers').some(d => /^firefox-/.test(d));
+// Checks every location a Firefox build can live: the managed-env path
+// (/opt/pw-browsers), an explicit PLAYWRIGHT_BROWSERS_PATH, and Playwright's
+// default cache (~/.cache/ms-playwright — where CI's `playwright install
+// firefox` lands). Without this, CI would install Firefox but never run it.
+const firefoxAvailable = (() => {
+  const os = require('os');
+  const dirs = [
+    process.env.PLAYWRIGHT_BROWSERS_PATH,
+    '/opt/pw-browsers',
+    require('path').join(os.homedir(), '.cache', 'ms-playwright'),
+  ].filter(Boolean);
+  for (const d of dirs) {
+    try { if (fs.existsSync(d) && fs.readdirSync(d).some(x => /^firefox-/.test(x))) return true; } catch (_) {}
+  }
+  return false;
+})();
 
 const projects = [
   {

--- a/dev/playwright.config.js
+++ b/dev/playwright.config.js
@@ -1,0 +1,37 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Playwright config for Ghost in the Loop boot-timing tests.
+ *
+ * These tests catch the class of bug unit tests CANNOT:
+ * script behavior at document-start, when document.head/body are null.
+ *
+ * Run locally:  npm run test:e2e
+ * Run in CI:    same, via .github/workflows/test.yml
+ */
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.js',
+  timeout: 30_000,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['json', { outputFile: 'e2e-results.json' }]] : 'list',
+  use: {
+    headless: true,
+    actionTimeout: 10_000,
+    trace: 'retain-on-failure',
+    // Managed environments pre-install chromium at a fixed path; use it if
+    // present instead of downloading a version-pinned browser build.
+    launchOptions: require('fs').existsSync('/opt/pw-browsers/chromium/chrome-linux/chrome')
+      ? { executablePath: '/opt/pw-browsers/chromium/chrome-linux/chrome' }
+      : (require('fs').existsSync('/opt/pw-browsers/chromium-1194/chrome-linux/chrome')
+        ? { executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome' } : {}),
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/dev/tests/canary.test.js
+++ b/dev/tests/canary.test.js
@@ -1,0 +1,40 @@
+/**
+ * CANARY DIAGNOSTIC TOOL — static guards (v8.2.0)
+ * The canary's whole value is being an INDEPENDENT, TT-safe probe. These
+ * lock in the properties that make it trustworthy on a page like Gemini.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '../diagnostics/gitl-canary.user.js'), 'utf8');
+
+describe('Execution canary', () => {
+  test('is a valid userscript (has a UserScript header + version)', () => {
+    expect(SRC).toMatch(/\/\/ ==UserScript==/);
+    expect(SRC).toMatch(/\/\/ @version\s+\d+\.\d+\.\d+/);
+  });
+
+  test('is Trusted-Types-safe: no innerHTML string sinks', () => {
+    // The canary must work on Gemini (require-trusted-types-for 'script'),
+    // which is exactly what broke Ghost. Building via DOM APIs is mandatory.
+    expect(SRC).not.toMatch(/\.innerHTML\s*=/);
+    expect(SRC).not.toMatch(/insertAdjacentHTML/);
+    expect(SRC).not.toMatch(/outerHTML\s*=/);
+    expect(SRC).not.toMatch(/document\.write/);
+  });
+
+  test('stays independent of Ghost core (no GITL_* / GHOST references)', () => {
+    // It reports ON Ghost by reading the DOM beacon, but must not depend on
+    // any of Ghost's internals — that independence is the point.
+    expect(SRC).not.toMatch(/\bGITL_NET\b/);
+    expect(SRC).not.toMatch(/\bGHOST\b\./);
+    // It DOES read Ghost's public DOM signals.
+    expect(SRC).toContain('data-gitl-boot');
+    expect(SRC).toContain("getElementById('gitl')");
+  });
+
+  test('mounts its host on documentElement (survives body replacement)', () => {
+    expect(SRC).toContain('attachShadow');
+    expect(SRC).toContain('html.appendChild(host)');
+  });
+});

--- a/dev/tests/e2e/bootdiag.spec.js
+++ b/dev/tests/e2e/bootdiag.spec.js
@@ -1,0 +1,111 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * BOOT DIAGNOSTICS + PANEL SELF-HEAL E2E (v8.1.4)
+ *
+ * Context: on the user's phone, v8.1.3 was confirmed INSTALLED + ACTIVE on
+ * Gemini via the Tampermonkey dashboard, yet #gitl never entered the DOM —
+ * and the only diagnostics available (static page saves, a console that
+ * forwarded a single cross-origin-masked error) couldn't say why. These
+ * tests exercise the two instruments added to make that diagnosable:
+ *   1. A boot beacon on <html data-gitl-boot="…"> that a plain page-save
+ *      captures: `ok:<ver>` on success, `error:<stage>` on a boot throw.
+ *   2. Fail-loud: a boot throw surfaces a visible #gitl-fatal banner instead
+ *      of dying silently.
+ *   3. Panel self-heal: if the page framework removes #gitl, it re-mounts.
+ */
+
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+  window.GM_notification = () => {};
+`;
+
+const MOCK = 'file://' + path.join(__dirname, 'mock-chat.html');
+
+test.describe('Boot beacon + panel presence', () => {
+  test('successful boot: beacon reads ok:<ver> and #gitl is in the DOM', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(beacon).toMatch(/^ok:8\.1\.\d+$/);
+    expect(mounted).toBe(true);
+  });
+
+  test('the beacon is written even before boot completes (started)', async ({ page }) => {
+    // A page-save taken mid-boot should still show the script began executing.
+    await page.addInitScript(GM);
+    await page.addInitScript(`document.documentElement.setAttribute('data-precheck','1')`);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    // No wait — grab immediately; must be at least 'started'.
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    expect(beacon).not.toBeNull();
+  });
+});
+
+test.describe('Fail-loud: a boot throw is visible, not silent', () => {
+  test('forcing the boot callback to throw shows the #gitl-fatal banner + error beacon', async ({ page }) => {
+    await page.addInitScript(GM);
+    // Break the first thing the boot callback does — new MutationObserver().observe(document.body,…).
+    // This throws INSIDE safeBoot's callback, exercising _gitlFatal('boot', …).
+    await page.addInitScript(`
+      const _RealMO = window.MutationObserver;
+      let _armed = false;
+      // Arm only after a tick so the script's own top-level observers still work;
+      // the boot callback runs at document-idle, after this.
+      setTimeout(() => { _armed = true; }, 0);
+      window.MutationObserver = class extends _RealMO {
+        observe(...a) { if (_armed) throw new Error('e2e-forced-boot-throw'); return super.observe(...a); }
+      };
+    `);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const banner = await page.evaluate(() => {
+      const b = document.getElementById('gitl-fatal');
+      return b ? b.textContent : null;
+    });
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    const stored = await page.evaluate(() => window.GM_getValue('lastBootError', ''));
+
+    expect(banner).toContain('couldn’t start');
+    expect(beacon).toBe('error:boot');
+    expect(stored).toContain('e2e-forced-boot-throw');
+  });
+});
+
+test.describe('Panel self-heal: re-mount after the page removes it', () => {
+  test('removing #gitl triggers a re-mount', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    // Sanity: mounted first.
+    expect(await page.evaluate(() => !!document.getElementById('gitl'))).toBe(true);
+
+    // Simulate an SPA framework wiping the panel out of the body.
+    await page.evaluate(() => document.getElementById('gitl').remove());
+    // Watchdog is a MutationObserver (fast) plus a 3s poll — give the observer a beat.
+    await page.waitForTimeout(600);
+
+    const back = await page.evaluate(() => !!document.getElementById('gitl'));
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    expect(back).toBe(true);
+    expect(beacon).toMatch(/^remounted:\d+$/);
+  });
+});

--- a/dev/tests/e2e/bootdiag.spec.js
+++ b/dev/tests/e2e/bootdiag.spec.js
@@ -40,7 +40,7 @@ test.describe('Boot beacon + panel presence', () => {
 
     const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
     const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
-    expect(beacon).toMatch(/^ok:8\.1\.\d+$/);
+    expect(beacon).toMatch(/^ok:8\.\d+\.\d+$/);
     expect(mounted).toBe(true);
   });
 

--- a/dev/tests/e2e/bootdiag.spec.js
+++ b/dev/tests/e2e/bootdiag.spec.js
@@ -56,34 +56,51 @@ test.describe('Boot beacon + panel presence', () => {
   });
 });
 
-test.describe('Fail-loud: a boot throw is visible, not silent', () => {
-  test('forcing the boot callback to throw shows the #gitl-fatal banner + error beacon', async ({ page }) => {
+test.describe('Transactional boot: optional-phase failure never suppresses the panel', () => {
+  test('breaking MutationObserver (optional phases) still mounts the panel', async ({ page }) => {
+    // Pre-v8.2.0 the continue-observer was the boot callback's FIRST statement,
+    // so breaking .observe() killed the whole boot. It is now an OPTIONAL phase
+    // that runs AFTER the panel is mounted — so breaking it must degrade
+    // gracefully, never blank the panel. (Critical-phase failure being LOUD is
+    // covered by trustedtypes.spec.js "policy blocked → fails loud".)
     await page.addInitScript(GM);
-    // Break the first thing the boot callback does — new MutationObserver().observe(document.body,…).
-    // That is the FIRST .observe() call in the whole script's execution order
-    // (the redetect + panel-sentinel observers run later/on demand), so an
-    // UNCONDITIONAL throw deterministically fails exactly the boot callback,
-    // in every engine. (An earlier timing-armed version raced boot in Firefox.)
     await page.addInitScript(`
       const _RealMO = window.MutationObserver;
       window.MutationObserver = class extends _RealMO {
-        observe() { throw new Error('e2e-forced-boot-throw'); }
+        observe() { throw new Error('e2e-observer-broken'); }
       };
     `);
     await page.addInitScript(RAW);
     await page.goto(MOCK);
     await page.waitForTimeout(800);
 
-    const banner = await page.evaluate(() => {
-      const b = document.getElementById('gitl-fatal');
-      return b ? b.textContent : null;
-    });
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
     const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
-    const stored = await page.evaluate(() => window.GM_getValue('lastBootError', ''));
+    const fatal = await page.evaluate(() => !!document.getElementById('gitl-fatal'));
+    // The broken optional phases are recorded in the persisted Timeline.
+    const brokenPhases = await page.evaluate(() => {
+      try {
+        const tl = JSON.parse(window.GM_getValue('gitlTimeline', '[]'));
+        return tl.filter(e => e.type === 'boot_phase' && e.data && e.data.ok === false)
+                 .map(e => e.data.name);
+      } catch (_) { return []; }
+    });
 
-    expect(banner).toContain('couldn’t start');
-    expect(beacon).toBe('error:boot');
-    expect(stored).toContain('e2e-forced-boot-throw');
+    expect(mounted).toBe(true);              // panel survives the optional failure
+    expect(beacon).toMatch(/^ok:8\.\d+\.\d+$/);
+    expect(fatal).toBe(false);               // NOT a fatal — optional degraded only
+    expect(brokenPhases).toContain('continue-observer');
+  });
+
+  test('the singleton is committed only after the panel is up', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+    const committed = await page.evaluate(() => window.__GITL_V8__ === true);
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(mounted).toBe(true);
+    expect(committed).toBe(true);
   });
 });
 

--- a/dev/tests/e2e/bootdiag.spec.js
+++ b/dev/tests/e2e/bootdiag.spec.js
@@ -60,15 +60,14 @@ test.describe('Fail-loud: a boot throw is visible, not silent', () => {
   test('forcing the boot callback to throw shows the #gitl-fatal banner + error beacon', async ({ page }) => {
     await page.addInitScript(GM);
     // Break the first thing the boot callback does — new MutationObserver().observe(document.body,…).
-    // This throws INSIDE safeBoot's callback, exercising _gitlFatal('boot', …).
+    // That is the FIRST .observe() call in the whole script's execution order
+    // (the redetect + panel-sentinel observers run later/on demand), so an
+    // UNCONDITIONAL throw deterministically fails exactly the boot callback,
+    // in every engine. (An earlier timing-armed version raced boot in Firefox.)
     await page.addInitScript(`
       const _RealMO = window.MutationObserver;
-      let _armed = false;
-      // Arm only after a tick so the script's own top-level observers still work;
-      // the boot callback runs at document-idle, after this.
-      setTimeout(() => { _armed = true; }, 0);
       window.MutationObserver = class extends _RealMO {
-        observe(...a) { if (_armed) throw new Error('e2e-forced-boot-throw'); return super.observe(...a); }
+        observe() { throw new Error('e2e-forced-boot-throw'); }
       };
     `);
     await page.addInitScript(RAW);

--- a/dev/tests/e2e/mock-chat-tt.html
+++ b/dev/tests/e2e/mock-chat-tt.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <!-- Reproduces Gemini's enforcement: under require-trusted-types-for
+       'script', assigning a plain string to .innerHTML THROWS. Chromium
+       enforces this from a meta CSP at parse time. No `trusted-types`
+       allow-list directive here, so creating a policy is permitted — which
+       is the case GITL v8.1.5's `gitl-ui` policy relies on. -->
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+  <title>Mock AI Chat (Trusted Types enforced) — GITL e2e harness</title>
+</head>
+<body>
+  <main>
+    <div class="conversation">
+      <div class="message assistant" data-message-author-role="assistant">Test AI Message</div>
+    </div>
+    <div class="composer">
+      <div
+        id="prompt-textarea"
+        class="ProseMirror"
+        contenteditable="true"
+        data-placeholder="Message..."
+        role="textbox"></div>
+      <button data-testid="send-button" aria-label="Send">Send</button>
+    </div>
+  </main>
+</body>
+</html>

--- a/dev/tests/e2e/netboot.spec.js
+++ b/dev/tests/e2e/netboot.spec.js
@@ -1,0 +1,116 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * NETWORK-INTERCEPTOR BOOT SAFETY E2E (v8.1.3)
+ *
+ * Field report: Ghost "doesn't seem to load" on gemini.google.com. A
+ * SingleFile capture of the live page proved #gitl never mounted at all —
+ * not a selector-matching problem, a full boot failure with zero visible
+ * symptom (no error, no panel, nothing — SingleFile captures Grammarly's
+ * live DOM injections in the same page, so the absence of ANY GITL trace
+ * ruled out "it ran but couldn't find selectors").
+ *
+ * Root cause: GITL_NET.install() runs at module top-level, OUTSIDE
+ * safeBoot()'s try/catch, and did THREE unguarded strict-mode property
+ * writes (window.fetch, XHR.prototype.open, XHR.prototype.send). If a page
+ * has hardened any of those (Object.defineProperty writable:false — a real
+ * pattern on security-conscious sites), the assignment throws and — because
+ * nothing catches it — kills the ENTIRE script before a single line of
+ * panel code runs.
+ *
+ * These tests freeze window.fetch (and separately XHR.prototype.send)
+ * BEFORE the script loads and assert the panel still mounts.
+ */
+
+const SCRIPT = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+`;
+
+const MOCK = 'file://' + path.join(__dirname, 'mock-chat.html');
+
+const FREEZE_FETCH = `
+  Object.defineProperty(window, 'fetch', {
+    value: window.fetch.bind(window),
+    writable: false,
+    configurable: false
+  });
+`;
+
+const FREEZE_XHR_SEND = `
+  Object.defineProperty(XMLHttpRequest.prototype, 'send', {
+    value: XMLHttpRequest.prototype.send,
+    writable: false,
+    configurable: false
+  });
+`;
+
+test.describe('Boot survives a hardened page (the Gemini reproduction)', () => {
+
+  test('window.fetch frozen non-writable — panel still mounts', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.addInitScript(GM);
+    await page.addInitScript(FREEZE_FETCH);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(mounted).toBe(true);
+    // The frozen property must not have produced an UNCAUGHT page error —
+    // it's allowed to be caught-and-logged internally (console.warn), but
+    // it must never escape to a real uncaught exception.
+    expect(errors.filter(e => /fetch/i.test(e))).toEqual([]);
+  });
+
+  test('XMLHttpRequest.prototype.send frozen non-writable — panel still mounts', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.addInitScript(GM);
+    await page.addInitScript(FREEZE_XHR_SEND);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(mounted).toBe(true);
+    expect(errors.length).toBe(0);
+  });
+
+  test('both frozen at once (worst case) — panel still mounts', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+
+    await page.addInitScript(GM);
+    await page.addInitScript(FREEZE_FETCH);
+    await page.addInitScript(FREEZE_XHR_SEND);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(mounted).toBe(true);
+    expect(errors.length).toBe(0);
+  });
+
+  test('normal (unfrozen) page still installs the interceptor as before', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    expect(mounted).toBe(true);
+  });
+});

--- a/dev/tests/e2e/routefix.spec.js
+++ b/dev/tests/e2e/routefix.spec.js
@@ -1,0 +1,67 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * ROUTE-CHANGE E2E (v8.1.2) — the Grok "paused 1s after a good send" bug.
+ *
+ * Field report: send_ok, then "Route changed — paused" one second later.
+ * Grok (like most chat platforms) assigns a "/c/<uuid>" URL to a brand-new
+ * conversation right after the first message — that's a same-conversation
+ * continuation, not real navigation, and must not pause a running loop.
+ * A genuine navigation to a different host still should.
+ */
+
+const SCRIPT = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '')
+  .replace(/(\}\)\(\)\s*;?\s*)$/, 'window.__GITL_GHOST = GHOST;\n$1');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+`;
+
+const MOCK = 'file://' + path.join(__dirname, 'mock-chat.html');
+
+test.describe('Route change — post-send conversation-id URL does not pause', () => {
+
+  test('same-host pushState right after a send keeps the loop RUNNING', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const G = window.__GITL_GHOST;
+      G.loop.state = 'RUNNING';
+      G.loop.lastActivity = Date.now();     // "just sent" within the 15s window
+      history.pushState({}, '', location.pathname + '#c/00000000-fake-uuid');
+    });
+    await page.waitForTimeout(200);
+
+    const state = await page.evaluate(() => window.__GITL_GHOST.loop.state);
+    expect(state).toBe('RUNNING');
+  });
+
+  test('a route change with NO recent send still pauses (real navigation)', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(MOCK);
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const G = window.__GITL_GHOST;
+      G.loop.state = 'RUNNING';
+      G.loop.lastActivity = Date.now() - 60000;   // nothing sent recently
+      G.loop.sendPending = false;
+      history.pushState({}, '', location.pathname + '#settings');
+    });
+    await page.waitForTimeout(200);
+
+    const state = await page.evaluate(() => window.__GITL_GHOST.loop.state);
+    expect(state).toBe('PAUSED');
+  });
+});

--- a/dev/tests/e2e/routefix.spec.js
+++ b/dev/tests/e2e/routefix.spec.js
@@ -13,9 +13,14 @@ const path = require('path');
  * A genuine navigation to a different host still should.
  */
 
-const SCRIPT = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
-  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '')
-  .replace(/(\}\)\(\)\s*;?\s*)$/, 'window.__GITL_GHOST = GHOST;\n$1');
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+// Expose a closure local for assertions. v8.1.4 wrapped the IIFE body in
+// try/catch, so inject INSIDE the try (before the outer catch) where GHOST is
+// in scope; fall back to the old before-`})()` spot for pre-8.1.4 builds.
+const SCRIPT = /\n\} catch\(__gitlBootErr\)/.test(RAW)
+  ? RAW.replace(/\n\} catch\(__gitlBootErr\)/, '\nwindow.__GITL_GHOST = GHOST;\n} catch(__gitlBootErr)')
+  : RAW.replace(/(\}\)\(\)\s*;?\s*)$/, 'window.__GITL_GHOST = GHOST;\n$1');
 
 const GM = `
   window.__gmStore = {};

--- a/dev/tests/e2e/sendsafety.spec.js
+++ b/dev/tests/e2e/sendsafety.spec.js
@@ -85,6 +85,58 @@ test.describe('Send safety — no trap button is ever chosen', () => {
     expect(picked).toBe('true-send');
   });
 
+  test('same-form popup toggles (#model-select-trigger, #composer-plus-btn) are refused — issues #4/#5', async ({ page }) => {
+    // The exact field trap: a model-picker and a "+" attach menu live INSIDE
+    // the composer form next to the input, so the heuristic's "same-form"
+    // signal alone used to qualify them and SelectorMemory learned the wrong
+    // control (#model-select-trigger on Grok, #composer-plus-btn on ChatGPT).
+    // With no real send present, getSendBtn must return NOTHING rather than a
+    // dropdown — and it must not persist a learned 'send' selector.
+    const FORM_PAGE = `data:text/html,${encodeURIComponent(`<!doctype html>
+      <html><body><main><form id="composer">
+        <button id="model-select-trigger" aria-haspopup="listbox" aria-label="Grok 4"><svg width="16" height="16"></svg></button>
+        <button id="composer-plus-btn" aria-expanded="false" aria-label="Add photos & files"><svg width="16" height="16"></svg></button>
+        <textarea id="chat-box" placeholder="Ask anything"></textarea>
+      </form></main></body></html>`)}`;
+
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(FORM_PAGE);
+    await page.waitForTimeout(600);
+
+    // Force the input to be found and the heuristic send tier to run.
+    const picked = await page.evaluate(() => {
+      window.__GITL_Adapter.getInput();
+      const b = window.__GITL_Adapter.getSendBtn();
+      return b ? (b.id || b.getAttribute('aria-label') || b.tagName) : null;
+    });
+    const learnedSend = await page.evaluate(() => {
+      try {
+        const mem = JSON.parse(window.GM_getValue('gitlLearnedSelectors', '{}'));
+        const host = mem[location.hostname] || {};
+        return host.send ? host.send.sel : null;
+      } catch (_) { return 'parse-error'; }
+    });
+
+    expect(picked).toBe(null);          // never a model-picker or "+" menu
+    expect(learnedSend).toBe(null);     // and nothing wrong gets persisted
+
+    // Now add the genuine send button in the same form — it must win.
+    await page.evaluate(() => {
+      const b = document.createElement('button');
+      b.id = 'true-send';
+      b.setAttribute('type', 'submit');
+      b.setAttribute('aria-label', 'Send message');
+      b.innerHTML = '<svg width="16" height="16"></svg>';
+      document.getElementById('composer').appendChild(b);
+    });
+    const real = await page.evaluate(() => {
+      const b = window.__GITL_Adapter.getSendBtn();
+      return b ? b.id : null;
+    });
+    expect(real).toBe('true-send');
+  });
+
   test('a ROTTED configured selector (class*="send" on a Copy button) is refused', async ({ page }) => {
     // The generic profile ships 'button[class*="send" i]'. After a site
     // redesign that class can land on a message-action control. The veto

--- a/dev/tests/e2e/sendsafety.spec.js
+++ b/dev/tests/e2e/sendsafety.spec.js
@@ -16,10 +16,15 @@ const path = require('path');
  * moment one exists.
  */
 
-const SCRIPT = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
-  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '')
-  // expose the adapter for assertions
-  .replace(/(\}\)\(\)\s*;?\s*)$/, 'window.__GITL_Adapter = Adapter; window.__GITL_SelMem = SelectorMemory;\n$1');
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+// Expose closure locals for assertions. v8.1.4 wrapped the IIFE body in
+// try/catch, so inject INSIDE the try (before the outer catch) where Adapter
+// is in scope; fall back to the old before-`})()` spot for pre-8.1.4 builds.
+const EXPOSE = 'window.__GITL_Adapter = Adapter; window.__GITL_SelMem = SelectorMemory;';
+const SCRIPT = /\n\} catch\(__gitlBootErr\)/.test(RAW)
+  ? RAW.replace(/\n\} catch\(__gitlBootErr\)/, '\n' + EXPOSE + '\n} catch(__gitlBootErr)')
+  : RAW.replace(/(\}\)\(\)\s*;?\s*)$/, EXPOSE + '\n$1');
 
 const GM = `
   window.__gmStore = {};

--- a/dev/tests/e2e/sendsafety.spec.js
+++ b/dev/tests/e2e/sendsafety.spec.js
@@ -1,0 +1,107 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * SEND SAFETY E2E (v8.1) — the DeepSeek "Copy" incident, reproduced.
+ *
+ * Field report: on chat.deepseek.com the heuristic send tier clicked the
+ * reply's "Copy" button (svg icon + proximity beat the old 3.5 threshold)
+ * and the user's prompt was copied instead of sent.
+ *
+ * These tests run the REAL script in a REAL browser against a page that has
+ * no configured send button — only message-action traps near the composer —
+ * and assert Ghost refuses every trap, then picks the true send button the
+ * moment one exists.
+ */
+
+const SCRIPT = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '')
+  // expose the adapter for assertions
+  .replace(/(\}\)\(\)\s*;?\s*)$/, 'window.__GITL_Adapter = Adapter; window.__GITL_SelMem = SelectorMemory;\n$1');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+`;
+
+const TRAP_PAGE = `data:text/html,${encodeURIComponent(`<!doctype html>
+<html><body>
+  <main>
+    <div class="message assistant"><div class="markdown">A reply.</div>
+      <!-- message-action traps: icon buttons with svg, right next to the composer -->
+      <button aria-label="Copy" id="trap-copy"><svg width="16" height="16"></svg></button>
+      <button aria-label="Download" id="trap-dl"><svg width="16" height="16"></svg></button>
+      <button aria-label="Regenerate" id="trap-regen"><svg width="16" height="16"></svg></button>
+      <button id="trap-anon"><svg width="16" height="16"></svg></button>
+    </div>
+    <footer>
+      <textarea id="chat-box" placeholder="Message the model"></textarea>
+    </footer>
+  </main>
+</body></html>`)}`;
+
+test.describe('Send safety — no trap button is ever chosen', () => {
+
+  test('with only traps present, getSendBtn returns nothing', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(TRAP_PAGE);
+    await page.waitForTimeout(600);
+
+    const picked = await page.evaluate(() => {
+      const b = window.__GITL_Adapter.getSendBtn();
+      return b ? (b.getAttribute('aria-label') || b.id || b.tagName) : null;
+    });
+    expect(picked).toBe(null);
+  });
+
+  test('a real Send button wins once it exists — and traps still lose', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(TRAP_PAGE);
+    await page.waitForTimeout(600);
+
+    await page.evaluate(() => {
+      const b = document.createElement('button');
+      b.id = 'true-send';
+      b.setAttribute('aria-label', 'Send message');
+      b.innerHTML = '<svg width="16" height="16"></svg>';
+      document.querySelector('footer').appendChild(b);
+    });
+
+    const picked = await page.evaluate(() => {
+      const b = window.__GITL_Adapter.getSendBtn();
+      return b ? b.id : null;
+    });
+    expect(picked).toBe('true-send');
+  });
+
+  test('a ROTTED configured selector (class*="send" on a Copy button) is refused', async ({ page }) => {
+    // The generic profile ships 'button[class*="send" i]'. After a site
+    // redesign that class can land on a message-action control. The veto
+    // must beat the configured tier too — this was the second half of the
+    // DeepSeek incident risk.
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(TRAP_PAGE);
+    await page.waitForTimeout(600);
+
+    await page.evaluate(() => {
+      const b = document.createElement('button');
+      b.className = 'msg-send-utils';            // matches button[class*="send" i]
+      b.setAttribute('aria-label', 'Copy');      // …but it's a copy control
+      b.innerHTML = '<svg width="16" height="16"></svg>';
+      document.querySelector('footer').appendChild(b);
+    });
+
+    const picked = await page.evaluate(() => {
+      const b = window.__GITL_Adapter.getSendBtn();
+      return b ? (b.getAttribute('aria-label') || b.id) : null;
+    });
+    expect(picked).toBe(null);
+  });
+});

--- a/dev/tests/e2e/sentinel.spec.js
+++ b/dev/tests/e2e/sentinel.spec.js
@@ -1,0 +1,99 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * PANEL SENTINEL E2E (v8.2.0) — bounded, visibility-aware liveness.
+ *
+ * Replaces the v8.1.4 watchdog (absence-only, unbounded). Verifies:
+ *   1. a host that moves #gitl into a display:none container is rescued
+ *      (visibility awareness, not just absence);
+ *   2. a relentless remover trips the CIRCUIT BREAKER — remounts are capped
+ *      and a visible note appears, instead of an infinite append/remove storm.
+ */
+
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+  window.GM_notification = () => {};
+`;
+
+const MOCK = 'file://' + path.join(__dirname, 'mock-chat.html');
+
+test.describe('Panel sentinel', () => {
+
+  test('rescues a panel hidden inside a display:none container (visibility-aware)', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+    expect(await page.evaluate(() => !!document.getElementById('gitl'))).toBe(true);
+
+    // Host moves #gitl into a hidden subtree (connected, but not visible) —
+    // the old absence-only watchdog would NOT have caught this.
+    await page.evaluate(() => {
+      const hidden = document.createElement('div');
+      hidden.style.display = 'none';
+      document.body.appendChild(hidden);
+      hidden.appendChild(document.getElementById('gitl'));
+    });
+    await page.waitForTimeout(700);
+
+    const visible = await page.evaluate(() => {
+      const n = document.getElementById('gitl');
+      if (!n) return false;
+      const st = getComputedStyle(n);
+      const r = n.getBoundingClientRect();
+      return st.display !== 'none' && st.visibility !== 'hidden' && (r.width > 2 || r.height > 2);
+    });
+    expect(visible).toBe(true);   // sentinel re-appended it to body → visible again
+  });
+
+  test('a relentless remover trips the bounded circuit breaker (no infinite storm)', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(MOCK);
+    await page.waitForTimeout(800);
+
+    // Remove #gitl on every DOM mutation — a hostile re-render loop.
+    await page.evaluate(() => {
+      const killer = new MutationObserver(() => {
+        const n = document.getElementById('gitl');
+        if (n) n.remove();
+      });
+      killer.observe(document.documentElement, { childList: true, subtree: true });
+      // Kick it off.
+      const n = document.getElementById('gitl');
+      if (n) n.remove();
+    });
+    // Give the sentinel time to hit its cap and open the breaker.
+    await page.waitForTimeout(2500);
+
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    const breakerShown = await page.evaluate(() => !!document.getElementById('gitl-sentinel'));
+    const remountCount = await page.evaluate(() => {
+      try {
+        const tl = JSON.parse(window.GM_getValue('gitlTimeline', '[]'));
+        return tl.filter(e => e.type === 'panel_remount').length;
+      } catch (_) { return 0; }
+    });
+    const opened = await page.evaluate(() => {
+      try {
+        const tl = JSON.parse(window.GM_getValue('gitlTimeline', '[]'));
+        return tl.some(e => e.type === 'panel_circuit_open');
+      } catch (_) { return false; }
+    });
+
+    expect(opened).toBe(true);            // breaker opened
+    expect(breakerShown).toBe(true);      // visible note shown
+    expect(beacon).toBe('sentinel-open');
+    // Remounts are capped (MAX=5), NOT unbounded — the whole point.
+    expect(remountCount).toBeLessThanOrEqual(5);
+  });
+});

--- a/dev/tests/e2e/trustedtypes.spec.js
+++ b/dev/tests/e2e/trustedtypes.spec.js
@@ -61,7 +61,7 @@ test.describe('Trusted Types (the Gemini reproduction)', () => {
     const fatal = await page.evaluate(() => !!document.getElementById('gitl-fatal'));
 
     expect(mounted).toBe(true);           // panel is in the DOM despite TT enforcement
-    expect(beacon).toMatch(/^ok:8\.1\.\d+$/);
+    expect(beacon).toMatch(/^ok:8\.\d+\.\d+$/);
     expect(fatal).toBe(false);            // no fail-loud banner — boot completed
     // No uncaught Trusted-Types sink error escaped.
     expect(pageErrors.filter(e => /sink|trusted/i.test(e))).toEqual([]);

--- a/dev/tests/e2e/trustedtypes.spec.js
+++ b/dev/tests/e2e/trustedtypes.spec.js
@@ -1,0 +1,98 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * TRUSTED TYPES E2E (v8.1.5) — the real Gemini root cause, reproduced.
+ *
+ * Field evidence: on the reporter's phone, GITL v8.1.4's fail-loud banner read
+ *   "Element.innerHTML setter: Sink type mismatch violation blocked by CSP"
+ * on Gemini. Gemini enforces `require-trusted-types-for 'script'`; under it,
+ * assigning a plain string to .innerHTML throws, which killed boot on the very
+ * first render. No other supported platform enforces Trusted Types — which is
+ * exactly why the panel appeared everywhere except Gemini.
+ *
+ * These tests load the REAL userscript on a page that enforces Trusted Types
+ * (Chromium honours a meta `require-trusted-types-for` CSP), proving:
+ *   1. the fixture genuinely enforces TT (a raw innerHTML throws);
+ *   2. GITL v8.1.5 registers a policy and mounts #gitl anyway (the fix);
+ *   3. if policy creation is BLOCKED (restrictive allow-list case), GITL fails
+ *      LOUD — banner + error beacon + 'tt-policy-blocked' — never silently.
+ */
+
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+const GM = `
+  window.__gmStore = {};
+  window.GM_getValue = (k, d) => (window.__gmStore[k] !== undefined ? window.__gmStore[k] : d);
+  window.GM_setValue = (k, v) => { window.__gmStore[k] = v; };
+  window.GM_addStyle = (css) => { const s=document.createElement('style'); s.textContent=css; (document.head||document.documentElement).appendChild(s); };
+  window.GM_notification = () => {};
+`;
+
+const TT_PAGE = 'file://' + path.join(__dirname, 'mock-chat-tt.html');
+
+test.describe('Trusted Types (the Gemini reproduction)', () => {
+
+  test('the fixture really enforces Trusted Types (raw innerHTML throws)', async ({ page }) => {
+    await page.goto(TT_PAGE);
+    const threw = await page.evaluate(() => {
+      try { document.createElement('div').innerHTML = '<b>x</b>'; return false; }
+      catch (e) { return String(e.message || e); }
+    });
+    // If this is not a truthy error string, the rest of the suite is meaningless.
+    expect(threw).toBeTruthy();
+    expect(String(threw)).toMatch(/trusted|sink|policy|require-trusted-types/i);
+  });
+
+  test('v8.1.5 mounts #gitl on a Trusted-Types-enforced page (the fix)', async ({ page }) => {
+    const pageErrors = [];
+    page.on('pageerror', (e) => pageErrors.push(String(e)));
+
+    await page.addInitScript(GM);
+    await page.addInitScript(RAW);
+    await page.goto(TT_PAGE);
+    await page.waitForTimeout(900);
+
+    const mounted = await page.evaluate(() => !!document.getElementById('gitl'));
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+    const fatal = await page.evaluate(() => !!document.getElementById('gitl-fatal'));
+
+    expect(mounted).toBe(true);           // panel is in the DOM despite TT enforcement
+    expect(beacon).toMatch(/^ok:8\.1\.\d+$/);
+    expect(fatal).toBe(false);            // no fail-loud banner — boot completed
+    // No uncaught Trusted-Types sink error escaped.
+    expect(pageErrors.filter(e => /sink|trusted/i.test(e))).toEqual([]);
+  });
+
+  test('if policy creation is blocked, boot fails LOUD (never silent)', async ({ page }) => {
+    await page.addInitScript(GM);
+    // Simulate a restrictive `trusted-types` allow-list that forbids our
+    // policy: make createPolicy throw. GITL must then degrade loudly.
+    await page.addInitScript(`
+      if (window.trustedTypes && window.trustedTypes.createPolicy) {
+        const _cp = window.trustedTypes.createPolicy.bind(window.trustedTypes);
+        window.trustedTypes.createPolicy = (name, rules) => {
+          if (name === 'gitl-ui') throw new TypeError('e2e: policy "gitl-ui" disallowed by trusted-types directive');
+          return _cp(name, rules);
+        };
+      }
+    `);
+    await page.addInitScript(RAW);
+    await page.goto(TT_PAGE);
+    await page.waitForTimeout(900);
+
+    const banner = await page.evaluate(() => {
+      const b = document.getElementById('gitl-fatal');
+      return b ? b.textContent : null;
+    });
+    const beacon = await page.evaluate(() => document.documentElement.getAttribute('data-gitl-boot'));
+
+    // The blocked-policy path marks the beacon, then the first innerHTML throws
+    // and the whole thing fails loud instead of a blank page.
+    expect(banner).toContain('couldn’t start');
+    expect(beacon).toMatch(/^error:/);
+  });
+});

--- a/dev/tests/issuefixes.test.js
+++ b/dev/tests/issuefixes.test.js
@@ -1,0 +1,57 @@
+/**
+ * ISSUE FIXES (v8.1.2) — regression tests for two field-reported bugs.
+ *
+ * #1 [auto] probe_fail on Perplexity: sent fine, Deep Research thinks
+ *    silently for a while with zero assistant DOM nodes yet, loop paused
+ *    with "No output detected" ~12s later even though the model was
+ *    demonstrably still working (net traffic active). The later no-signal
+ *    branch already got an isGenerating() witness in d7; the earlier
+ *    "no text at all" branch never did.
+ *
+ * #2 [auto] manual on Grok: send_ok, then ONE SECOND later "Route changed
+ *    — paused" — the platform assigning a "/c/<uuid>" URL to a brand-new
+ *    conversation was mistaken for real navigation.
+ */
+const fs = require('fs'), path = require('path');
+const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+
+describe('Issue #1 — Perplexity: no-output branch respects isGenerating()', () => {
+  const block = src.slice(src.indexOf('const text = Adapter.getLastText();'), src.indexOf('const text = Adapter.getLastText();') + 900);
+
+  test('the !text branch checks isGenerating() before counting a stale tick', () => {
+    expect(block).toContain('if (!text) {');
+    expect(block).toContain('Adapter.isGenerating()');
+  });
+
+  test('the !text branch uses the per-platform stale budget, not a bare 5', () => {
+    expect(block).toContain('(PLAT && PLAT.staleTicks) || 5');
+  });
+
+  test('staleTicks resets to 0 while generating instead of accumulating', () => {
+    expect(block).toMatch(/isGenerating\(\)\) \{ L\.staleTicks = 0;/);
+  });
+});
+
+describe('Issue #2 — Grok: conversation-id URL assignment does not pause a running loop', () => {
+  test('route watcher checks same-host before pausing', () => {
+    expect(src).toContain('new URL(prevHref).hostname === location.hostname');
+  });
+
+  test('route watcher checks for a recent send before pausing', () => {
+    expect(src).toContain('GHOST.loop.sendPending || (Date.now() - (GHOST.loop.lastActivity || 0) < 15000)');
+  });
+
+  test('a same-host post-send route change is recorded, not treated as a pause trigger', () => {
+    expect(src).toContain("Timeline.record('route_id_assigned'");
+  });
+
+  test('a genuine cross-host route change still pauses a running loop', () => {
+    expect(src).toContain("enginePause('Route changed — paused')");
+  });
+
+  test('element caches are still cleared on every route change regardless of outcome', () => {
+    const m = src.match(/window\.addEventListener\('gitl:route', \(\) => \{[\s\S]*?\n\}\);/);
+    expect(m).not.toBeNull();
+    expect(m[0]).toContain('_clearElementCaches();');
+  });
+});

--- a/dev/tests/mislearn.test.js
+++ b/dev/tests/mislearn.test.js
@@ -1,0 +1,121 @@
+/**
+ * WRONG-SELECTOR MISLEARN (v8.2.1) — regression suite for issues #4 and #5.
+ *
+ * Field evidence:
+ *  #5 [auto] probe_fail on Grok    → learned send selector = #model-select-trigger
+ *  #4 [auto] probe_fail on ChatGPT → learned send selector = #composer-plus-btn
+ *
+ * Both controls live INSIDE the composer form, so the heuristic tier's
+ * "same-form" positive signal alone qualified them as a send button, and
+ * nothing inspected their id or their popup-toggle nature. The result: the
+ * loop "sent" by clicking a model picker / attach menu, and the run stalled
+ * with "No output detected".
+ *
+ * Contract under test (the fix):
+ *  1. A popup-toggle (aria-haspopup / aria-expanded) is NEVER a safe send.
+ *  2. The element id is part of the veto surface (#model-select-trigger,
+ *     #composer-plus-btn read as unsafe even with an innocuous aria-label).
+ *  3. _heurSend cannot RETURN either control even when it is the only
+ *     same-form candidate near the input.
+ *  4. SelectorMemory.lookup('send') forgets a persisted wrong selector.
+ */
+/* Symbols arrive on global via tests/setup.js */
+
+/* Element stub compatible with _heurSend / _sendLooksSafe / derive / lookup */
+function makeBtn(attrs = {}, opts = {}) {
+  const attrMap = { ...attrs };
+  const el = {
+    tagName: opts.tag || 'BUTTON',
+    disabled: false,
+    textContent: opts.text || '',
+    className: opts.className || '',
+    getAttribute: (k) => (attrMap[k] !== undefined ? attrMap[k] : null),
+    setAttribute: (k, v) => { attrMap[k] = String(v); },
+    querySelector: (sel) => (sel === 'svg' && opts.svg ? {} : null),
+    closest: (sel) => (sel === 'form' ? (opts.form || null) : null),
+    getBoundingClientRect: () => opts.rect || { left: 100, top: 500, width: 40, height: 40, bottom: 540, right: 140 },
+    isConnected: true
+  };
+  return el;
+}
+
+describe('Issue #5 — Grok: #model-select-trigger must never look like send', () => {
+  test('a model-select dropdown is vetoed by its aria-haspopup', () => {
+    const modelPicker = makeBtn(
+      { id: 'model-select-trigger', 'aria-haspopup': 'listbox', 'aria-label': 'Grok 4' });
+    expect(_sendLooksSafe(modelPicker)).toBe(false);
+  });
+
+  test('the id alone (#model-select-trigger) reads as unsafe even without haspopup', () => {
+    const byId = makeBtn({ id: 'model-select-trigger', 'aria-label': 'Grok 4' });
+    expect(_sendLooksSafe(byId)).toBe(false);
+  });
+
+  test('SEND_VETO matches the "model" keyword', () => {
+    expect(SEND_VETO.test('model-select-trigger')).toBe(true);
+  });
+});
+
+describe('Issue #4 — ChatGPT: #composer-plus-btn must never look like send', () => {
+  test('the "+" attach menu is vetoed by its aria-expanded toggle', () => {
+    const plus = makeBtn(
+      { id: 'composer-plus-btn', 'aria-expanded': 'false', 'aria-label': 'Add photos & files' });
+    expect(_sendLooksSafe(plus)).toBe(false);
+  });
+
+  test('the id alone (#composer-plus-btn) reads as unsafe', () => {
+    const byId = makeBtn({ id: 'composer-plus-btn', 'aria-label': 'Add' });
+    expect(_sendLooksSafe(byId)).toBe(false);
+  });
+
+  test('a real ChatGPT send button is still accepted', () => {
+    const send = makeBtn({ 'data-testid': 'send-button', 'aria-label': 'Send prompt' });
+    expect(_sendLooksSafe(send)).toBe(true);
+  });
+});
+
+describe('_heurSend — a same-form popup-toggle can no longer be RETURNED', () => {
+  // Reproduce the trap: the only same-form candidate near the input is the
+  // model picker / "+" menu (svg icon, close to the composer). Pre-8.2.1 the
+  // "same-form" signal + proximity scored it past threshold and it was learned.
+  const form = { __isForm: true };
+  const anchor = {
+    getBoundingClientRect: () => ({ left: 90, top: 500, width: 300, height: 40, bottom: 540, right: 390 }),
+    closest: (sel) => (sel === 'form' ? form : null)
+  };
+
+  test('does not return #model-select-trigger even when it is the only same-form candidate', () => {
+    const picker = makeBtn(
+      { id: 'model-select-trigger', 'aria-haspopup': 'listbox' },
+      { svg: true, form, rect: { left: 100, top: 500, width: 40, height: 40, bottom: 540, right: 140 } });
+    const _qAllOrig = global._qAll;
+    // _heurSend iterates _qAll(['button','[role="button"]']); jsdom has none,
+    // so assert the gate directly: the candidate is filtered by _sendLooksSafe,
+    // which _heurSend now uses as its veto.
+    expect(_sendLooksSafe(picker)).toBe(false);
+    if (_qAllOrig) global._qAll = _qAllOrig;
+  });
+
+  test('_heurSend routes its veto through _sendLooksSafe (single source of truth)', () => {
+    const fs = require('fs'), path = require('path');
+    const s = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+    // The old inline `if (SEND_VETO.test(label)) continue;` is replaced by the
+    // shared gate so id + structural checks apply in the heuristic tier too.
+    expect(s).toContain('if (!_sendLooksSafe(el)) continue;');
+  });
+});
+
+describe('SelectorMemory.lookup — a persisted wrong send selector self-heals', () => {
+  test('lookup("send") calls forget() when the stored element is unsafe', () => {
+    const fs = require('fs'), path = require('path');
+    const s = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+    expect(s).toContain("if (kind === 'send' && !_sendLooksSafe(el)) { this.forget(kind); return null; }");
+  });
+
+  test('_sendLooksSafe structurally rejects popup toggles (haspopup + expanded)', () => {
+    const fs = require('fs'), path = require('path');
+    const s = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+    expect(s).toContain("if (el.getAttribute('aria-haspopup')) return false;");
+    expect(s).toContain("if (el.getAttribute('aria-expanded') != null) return false;");
+  });
+});

--- a/dev/tests/netboot.test.js
+++ b/dev/tests/netboot.test.js
@@ -1,0 +1,52 @@
+/**
+ * NETWORK INTERCEPTOR BOOT SAFETY (v8.1.3) — static/structural checks.
+ * Real crash reproduction lives in tests/e2e/netboot.spec.js (frozen
+ * window.fetch / XHR.prototype.send in an actual browser). These confirm
+ * the source shape the e2e depends on, and the lastBootError surfacing.
+ */
+const fs = require('fs'), path = require('path');
+const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+
+describe('GITL_NET.install() is fault-tolerant end to end', () => {
+  test('the fetch patch assignment is wrapped in try/catch', () => {
+    expect(src).toContain("try { if (typeof origFetch === 'function') UW.fetch = async function(...args) {");
+    expect(src).toContain("} catch(err) { console.warn('[GITL] fetch patch skipped:', err); }");
+  });
+
+  test('reading UW.fetch itself is guarded (a hardened getter could also throw)', () => {
+    expect(src).toContain('let origFetch; try { origFetch = UW.fetch; } catch(_) { origFetch = null; }');
+  });
+
+  test('the XHR patch block is wrapped in try/catch', () => {
+    expect(src).toContain("} catch(err) { console.warn('[GITL] XHR patch skipped:', err); }");
+  });
+
+  test('the WebSocket patch block is still wrapped (was already safe, must stay that way)', () => {
+    expect(src).toContain("} catch(err) { console.warn('[GITL] WebSocket patch skipped:', err); }");
+  });
+
+  test('the whole install() method has an outer catch as a last resort', () => {
+    expect(src).toContain('console.error(\'[GITL] Network interceptor failed to install — panel will still boot:\', err);');
+    expect(src).toContain("_save('lastNetInstallError'");
+  });
+
+  test('the top-level call site is guarded too — it used to run outside safeBoot entirely', () => {
+    expect(src).toContain('try { GITL_NET.install(); } catch(err) { console.error(');
+  });
+});
+
+describe('A prior boot failure is surfaced instead of living silently in GM storage', () => {
+  test('lastBootError is read back and pushed to DIAG on a later successful boot', () => {
+    expect(src).toContain("const lastBoot = GM_getValue('lastBootError', '');");
+    expect(src).toContain("DIAG.push('Previous page load failed to boot:");
+  });
+
+  test('lastNetInstallError is read back too', () => {
+    expect(src).toContain("const lastNet  = GM_getValue('lastNetInstallError', '');");
+  });
+
+  test('both are cleared after surfacing once, so they do not repeat every boot', () => {
+    expect(src).toMatch(/_save\('lastBootError', ''\)/);
+    expect(src).toMatch(/_save\('lastNetInstallError', ''\)/);
+  });
+});

--- a/dev/tests/selmem.test.js
+++ b/dev/tests/selmem.test.js
@@ -1,0 +1,128 @@
+/**
+ * SELECTOR MEMORY TESTS (v8.1)
+ * Self-healing learned locators (Healenium-style fallback tier).
+ * Contract:
+ *  1. derive() prefers stable attributes (id > data-testid > aria-label …)
+ *     and only returns a selector that UNIQUELY matches the element.
+ *  2. learn()/lookup() persist per-host in GM storage and survive reload.
+ *  3. forget() removes a bad entry; storage prunes beyond MAX_HOSTS.
+ *  4. Learned SEND selectors still pass the send veto (no learned Copy).
+ */
+/* Symbols arrive on global via tests/setup.js */
+const HOST = 'chatgpt.com';  // the VM context's location.hostname (setup.js)
+
+function el(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  const node = div.firstElementChild;
+  document.body.appendChild(node);
+  return node;
+}
+
+afterEach(() => { document.body.innerHTML = ''; SelectorMemory._data = null; });
+
+describe('SelectorMemory.derive', () => {
+  test('prefers #id when unique', () => {
+    const n = el('<textarea id="chat-input"></textarea>');
+    expect(SelectorMemory.derive(n)).toBe('#chat-input');
+  });
+
+  test('falls back to data-testid', () => {
+    const n = el('<div contenteditable="true" data-testid="composer"></div>');
+    expect(SelectorMemory.derive(n)).toBe('div[data-testid="composer"]');
+  });
+
+  test('falls back to aria-label', () => {
+    const n = el('<textarea aria-label="Ask anything"></textarea>');
+    expect(SelectorMemory.derive(n)).toBe('textarea[aria-label="Ask anything"]');
+  });
+
+  test('returns null when nothing is stable', () => {
+    const n = el('<textarea class="x9f3k"></textarea>');
+    expect(SelectorMemory.derive(n)).toBe(null);
+  });
+
+  test('returns null when the candidate is not unique', () => {
+    el('<textarea aria-label="Ask"></textarea>');
+    const n = el('<textarea aria-label="Ask"></textarea>');
+    expect(SelectorMemory.derive(n)).toBe(null);
+  });
+});
+
+describe('SelectorMemory.learn / lookup / forget', () => {
+  test('learn persists per-host and survives a fresh in-memory load', () => {
+    const n = el('<textarea id="composer-a"></textarea>');
+    expect(SelectorMemory.learn('input', n)).toBe('#composer-a');
+    SelectorMemory._data = null;             // simulate reload
+    const stored = SelectorMemory._load();
+    expect(stored[HOST].input.sel).toBe('#composer-a');
+  });
+
+  test('forget removes the entry', () => {
+    const n = el('<textarea id="composer-b"></textarea>');
+    SelectorMemory.learn('input', n);
+    SelectorMemory.forget('input');
+    expect(SelectorMemory._load()[HOST]?.input).toBeUndefined();
+  });
+
+  test('learn returns null for unlearnable elements (no throw)', () => {
+    const n = el('<textarea class="q1w2e3"></textarea>');
+    expect(SelectorMemory.learn('input', n)).toBe(null);
+  });
+
+  test('host pruning keeps storage bounded', () => {
+    const d = SelectorMemory._load();
+    for (let i = 0; i < SelectorMemory.MAX_HOSTS + 3; i++) {
+      d[`host${i}.example`] = { input: { sel: '#x', at: i } };
+    }
+    SelectorMemory._persist();
+    const n = el('<textarea id="composer-c"></textarea>');
+    SelectorMemory.learn('input', n);
+    expect(Object.keys(SelectorMemory._load()).length).toBeLessThanOrEqual(SelectorMemory.MAX_HOSTS);
+    // the just-touched host must survive pruning
+    expect(SelectorMemory._load()[HOST]).toBeDefined();
+  });
+});
+
+describe('Integration — Adapter and reDetect wiring', () => {
+  const fs = require('fs'), path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+
+  test('Adapter.getInput consults SelectorMemory before heuristics', () => {
+    expect(src).toContain("_q('in', PLAT.input) || SelectorMemory.lookup('input')");
+  });
+  test('learned send selectors are veto-checked', () => {
+    expect(src).toMatch(/kind === 'send' && !_sendLooksSafe\(el\)/);
+  });
+  test('reDetect clears heuristic caches too', () => {
+    expect(src).toContain('function _clearElementCaches()');
+    expect(src).toMatch(/_heurCache\.input = \{ el: null, ts: 0 \};/);
+  });
+  test('reDetect keeps watching after a miss (observer + interval)', () => {
+    expect(src).toContain('_redetectWatch.obs = new MutationObserver');
+    expect(src).toContain("_redetectWatch.timer = setInterval(_redetectCheck, 800)");
+  });
+  test('visibility self-heal is installed', () => {
+    expect(src).toContain("document.addEventListener('visibilitychange'");
+  });
+});
+
+describe('Sigil-free completion fallback (soft proceed)', () => {
+  const fs = require('fs'), path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+
+  test('soft proceed exists and is bounded to 2 nudges', () => {
+    expect(src).toContain("Timeline.record('soft_proceed'");
+    expect(src).toContain('(L.noSigilStreak || 0) < 2');
+  });
+  test('streak resets on real signals', () => {
+    const resets = src.match(/L\.noSigilStreak = 0; L\._nudgedTail = '';/g) || [];
+    expect(resets.length).toBeGreaterThanOrEqual(2);
+  });
+  test('nudge message re-states the sigil protocol', () => {
+    expect(src).toContain('[[GITL::PROCEED]] — more work remains');
+  });
+  test('Timeline.add typo is gone (would crash engineTick)', () => {
+    expect(src).not.toContain('Timeline.add(');
+  });
+});

--- a/dev/tests/sendsafety.test.js
+++ b/dev/tests/sendsafety.test.js
@@ -1,0 +1,72 @@
+/**
+ * SEND SAFETY TESTS (v8.1)
+ * Regression suite for the DeepSeek incident: the heuristic send tier
+ * clicked the reply's "Copy" button (svg icon + proximity scored past the
+ * old threshold) and the user's prompt was copied instead of sent.
+ *
+ * Contract under test:
+ *  1. SEND_VETO covers message-action verbs (copy/download/share/edit/…).
+ *  2. _sendLooksSafe rejects vetoed controls no matter which tier found them.
+ *  3. _heurSend requires a POSITIVE semantic signal (send word, type=submit,
+ *     or same-form) — svg + proximity alone must never win.
+ */
+/* Symbols arrive on global via tests/setup.js */
+
+/* Minimal element stub compatible with _heurSend/_sendLooksSafe */
+function makeBtn(attrs = {}, opts = {}) {
+  const attrMap = { ...attrs };
+  return {
+    tagName: 'BUTTON',
+    disabled: false,
+    textContent: opts.text || '',
+    className: opts.className || '',
+    getAttribute: (k) => (attrMap[k] !== undefined ? attrMap[k] : null),
+    querySelector: (sel) => (sel === 'svg' && opts.svg ? {} : null),
+    closest: (sel) => (sel === 'form' ? (opts.form || null) : null),
+    getBoundingClientRect: () => opts.rect || { left: 0, top: 0, width: 40, height: 40, bottom: 40, right: 40 },
+    isConnected: true
+  };
+}
+
+describe('SEND_VETO — message-action verbs are hard-vetoed', () => {
+  const vetoed = ['Copy', 'Download', 'Share', 'Edit message', 'Delete',
+    'Regenerate', 'Retry', 'Like', 'Dislike', 'Read aloud', 'Copy code',
+    'Stop generating', 'Voice mode', 'Attach file', 'DeepThink'];
+  for (const label of vetoed) {
+    test(`vetoes "${label}"`, () => expect(SEND_VETO.test(label)).toBe(true));
+  }
+  const allowed = ['Send', 'Send message', 'Submit', 'Send prompt', 'enviar'];
+  for (const label of allowed) {
+    test(`allows "${label}"`, () => expect(SEND_VETO.test(label)).toBe(false));
+  }
+});
+
+describe('_sendLooksSafe — tier-independent veto', () => {
+  test('rejects a copy button found by a configured selector', () => {
+    expect(_sendLooksSafe(makeBtn({ 'aria-label': 'Copy' }))).toBe(false);
+  });
+  test('rejects a download control', () => {
+    expect(_sendLooksSafe(makeBtn({}, { text: 'Download' }))).toBe(false);
+  });
+  test('accepts a real send button', () => {
+    expect(_sendLooksSafe(makeBtn({ 'aria-label': 'Send message' }))).toBe(true);
+  });
+  test('null is not safe', () => {
+    expect(_sendLooksSafe(null)).toBe(false);
+  });
+});
+
+describe('_heurSend — semantic gate (svg + proximity alone must never win)', () => {
+  test('source requires a positive semantic signal', () => {
+    // Structural check: the gate exists in the shipped source.
+    const fs = require('fs'), path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+    expect(src).toContain('const sem = SEND_WORDS.test(label)');
+    expect(src).toContain('if (!sem) continue;');
+  });
+  test('is exported and callable', () => {
+    expect(typeof _heurSend).toBe('function');
+    // No DOM candidates in jsdom → must return null/undefined, never throw.
+    expect(_heurSend(null) || null).toBe(null);
+  });
+});

--- a/dev/tests/setup.js
+++ b/dev/tests/setup.js
@@ -75,7 +75,7 @@ if (typeof __GITL_TEST_SINK__ !== 'undefined') {
     'FUZZY_PROCEED','FUZZY_HALT','WORKFLOW_LIBRARY','PERSONA_LIBRARY',
     'Workshop','WORKSHOP_LIMITS','allPersonas','allWorkflows',
     'SKIN','SKIN_TOKENS','SKIN_FX','SKIN_PRESETS',
-    'Adapter','_heurSend','_heurInput','SEND_WORDS','UW',
+    'Adapter','_heurSend','_heurInput','SEND_WORDS','SEND_VETO','_sendLooksSafe','SelectorMemory','reDetect','UW',
     'EXPLAIN','_explainLookup',
     'render','runDirectives','hasPendingDirectives','startLoop','stopLoop','resolvePersonaInject',
     'PERSONA_LIBRARY','PAYLOADS','POSTURES',

--- a/dev/tests/setup.js
+++ b/dev/tests/setup.js
@@ -88,8 +88,15 @@ if (typeof __GITL_TEST_SINK__ !== 'undefined') {
 }
 `;
 
-/* Find the last })(); and insert hook before it */
-const instrumented = noHeader.replace(/(\}\)\(\)\s*;?\s*)$/, `${EXPORT_HOOK}\n$1`);
+/* Inject the export hook so it runs where the closure's locals are visible.
+   v8.1.4 wrapped the whole IIFE body in `try { … } catch(__gitlBootErr){…}`,
+   so the symbols are block-scoped INSIDE that try. Insert the hook just before
+   the outer catch (still inside the try); fall back to the pre-8.1.4 layout
+   (before the final `})();`) when the wrapper isn't present. */
+const CATCH_RE = /\n\} catch\(__gitlBootErr\)/;
+const instrumented = CATCH_RE.test(noHeader)
+  ? noHeader.replace(CATCH_RE, `\n${EXPORT_HOOK}\n} catch(__gitlBootErr)`)
+  : noHeader.replace(/(\}\)\(\)\s*;?\s*)$/, `${EXPORT_HOOK}\n$1`);
 
 /* Sink object that the hook writes into */
 const sink = {};

--- a/dev/tests/workshop.test.js
+++ b/dev/tests/workshop.test.js
@@ -174,3 +174,49 @@ describe('Workshop — export round-trip', () => {
     expect(parsed.schema).toBe('gitl-workshop/1');
   });
 });
+
+describe('Workshop — v8.1 skin-in-bundle + share', () => {
+  const VALID_SKIN = { kind:'skin', gitlSkin:1, name:'Test Glow',
+    tokens:{ '--g-accent':'#4ade80' }, fx:{ ghost:'float' } };
+
+  test('skin-only bundle imports (no personas/workflows required)', () => {
+    const W = freshWorkshop();
+    const res = W.importBundle(JSON.stringify({ schema:'gitl-workshop/1', skin: VALID_SKIN }));
+    expect(res.ok).toBe(true);
+    expect(res.skin).toBe(1);
+    expect(GHOST.ui.skinTheme).toBe('custom');
+    expect(JSON.parse(GHOST.ui.customSkin).name).toBe('Test Glow');
+  });
+
+  test('invalid bundled skin is skipped, never fatal', () => {
+    const W = freshWorkshop();
+    W.addPersona('P', 'inject');
+    const bad = { schema:'gitl-workshop/1',
+      personas:[{ id:'q', label:'Q', inject:'z' }],
+      skin:{ kind:'skin', gitlSkin:1, name:'Evil', tokens:{ '--g-bg':'url(http://x)' } } };
+    const res = W.importBundle(JSON.stringify(bad));
+    expect(res.ok).toBe(true);
+    expect(res.personas).toBe(1);
+    // url( is stripped by the validator → skin has no valid tokens but is
+    // still a structurally valid (empty) skin OR is skipped — either way
+    // the import itself must succeed.
+  });
+
+  test('empty bundle without skin still errors', () => {
+    const W = freshWorkshop();
+    const res = W.importBundle(JSON.stringify({ schema:'gitl-workshop/1' }));
+    expect(res.ok).toBe(false);
+  });
+
+  test('shareText produces a paste-ready post with the JSON bundle', () => {
+    const W = freshWorkshop();
+    W.addPersona('Threat Modeler', 'think like an attacker');
+    W.addWorkflow('Deep Research', 'd', ['a', 'b', 'c']);
+    const t = W.shareText();
+    expect(t).toContain('Workshop pack:');
+    expect(t).toContain('👤 Threat Modeler');
+    expect(t).toContain('⛓ Deep Research (3 stages)');
+    expect(t).toContain('```json');
+    expect(t).toContain('"schema": "gitl-workshop/1"');
+  });
+});


### PR DESCRIPTION
FIX: DeepSeek clicked Copy instead of Send. Heuristic send tier now requires
a positive semantic signal (send word / type=submit / same-form); veto list
expanded to all message-action verbs and enforced on every tier via
_sendLooksSafe(), including configured and learned selectors.

FIX: models that never echo [[GITL]] sigils (DeepSeek) stranded the loop.
Sigil-free completion fallback auto-continues once with a protocol reminder,
pauses only after 2 consecutive sigil-free replies. Fixed latent
Timeline.add() crash in roadmap re-ask.

Re-detect: no longer one-shot — 12s MutationObserver+interval watch, clears
ALL element caches (heuristic tier was missed), resets stale net counters,
silent visibilitychange self-heal.

NEW: SelectorMemory — Healenium-style learned locators per host (derived
stable selector, verified unique, 12-host LRU), tried between configured
and heuristic tiers.

Reporter: 10-min dedupe (wired the unused _seen), learned-selector state in
reports, probe shows all three lookup tiers. Workshop: 🌐 Share copies a
paste-ready Discussions post; skins ride in .gitl.json bundles (validated,
skin-only bundles allowed).

Tests: 282 unit (48 new: sendsafety, selmem, workshop-share) + 10 e2e
(3 new real-browser send-safety traps incl. rotted-selector case). Extension
content.js rebuilt (was stale at 8.0.0).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TJ2irraMmwHMYvE6abZSFD