### PR TITLE
Release automation: fail-closed final publication bot

### DIFF
--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
   issues:
-    types: [labeled]
+    types: [opened]
 
 permissions:
   contents: write
@@ -30,7 +30,9 @@ jobs:
   publish:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && github.event.label.name == 'release-approved')
+      (github.event_name == 'issues' &&
+       github.event.issue.author_association == 'OWNER' &&
+       startsWith(github.event.issue.title, '[release-final]'))
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -45,7 +47,6 @@ jobs:
           DISPATCH_TARGET_SHA: ${{ inputs.target_sha }}
           DISPATCH_CONFIRM: ${{ inputs.confirm }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
         run: |
           set -euo pipefail
 
@@ -54,11 +55,6 @@ jobs:
             target_sha="$DISPATCH_TARGET_SHA"
             confirm="$DISPATCH_CONFIRM"
           else
-            if [[ "$ISSUE_AUTHOR_ASSOCIATION" != "OWNER" ]]; then
-              echo "Release requests triggered from issues must be authored by the repository owner." >&2
-              exit 1
-            fi
-
             version="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^version:[[:space:]]*//p')"
             target_sha="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^target_sha:[[:space:]]*//p')"
             confirm="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^confirm:[[:space:]]*//p')"

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -1,6 +1,11 @@
 name: Publish Final Release
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-final-release.yml'
+      - 'docs/RELEASE-AUTOMATION.md'
   workflow_dispatch:
     inputs:
       version:
@@ -26,6 +31,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  definition-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out proposed workflow
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check patch hygiene
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git diff --check "$BASE_SHA..$HEAD_SHA"
+          test -f .github/workflows/publish-final-release.yml
+          test -f docs/RELEASE-AUTOMATION.md
+
   verify:
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -19,23 +19,30 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 concurrency:
   group: final-release
   cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' &&
        github.event.issue.author_association == 'OWNER' &&
        startsWith(github.event.issue.title, '[release-final]'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GH_TOKEN: ${{ github.token }}
+    outputs:
+      version: ${{ steps.request.outputs.version }}
+      target_sha: ${{ steps.request.outputs.target_sha }}
+      tag: ${{ steps.request.outputs.tag }}
+      tag_exists: ${{ steps.gate.outputs.tag_exists }}
+      release_exists: ${{ steps.gate.outputs.release_exists }}
 
     steps:
       - name: Resolve release request
@@ -190,13 +197,91 @@ jobs:
         if: steps.gate.outputs.release_exists != 'true'
         run: npm run test:e2e
 
-      - name: Create immutable version tag
-        if: steps.gate.outputs.release_exists != 'true' && steps.gate.outputs.tag_exists != 'true'
+      - name: Stage verified release assets for publication job
+        if: steps.gate.outputs.release_exists != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-release-assets
+          path: |
+            test-results/release-candidate/ghost-in-the-loop.user.js
+            test-results/release-candidate/SHA256SUMS
+            test-results/release-candidate/package-manifest.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: verify
+    if: needs.verify.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out exact verified release target
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.verify.outputs.target_sha }}
+          fetch-depth: 0
+
+      - name: Revalidate target immediately before publication
+        id: revalidate
         shell: bash
         env:
-          VERSION: ${{ steps.request.outputs.version }}
-          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
-          TAG: ${{ steps.request.outputs.tag }}
+          TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --tags --force
+          main_sha="$(git rev-parse origin/main)"
+          if [[ "$TARGET_SHA" != "$main_sha" ]]; then
+            echo "Refusing publication: main moved from verified target $TARGET_SHA to $main_sha." >&2
+            exit 1
+          fi
+
+          tag_exists=false
+          release_exists=false
+
+          if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
+            tag_exists=true
+            tag_sha="$(git rev-list -n 1 "$TAG")"
+            if [[ "$tag_sha" != "$TARGET_SHA" ]]; then
+              echo "Refusing publication: existing $TAG points to $tag_sha, not $TARGET_SHA." >&2
+              exit 1
+            fi
+          fi
+
+          if release_state="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv' 2>/dev/null)"; then
+            draft="${release_state%%$'\t'*}"
+            prerelease="${release_state#*$'\t'}"
+            if [[ "$draft" == "false" && "$prerelease" == "false" ]]; then
+              release_exists=true
+            else
+              echo "Refusing publication: $TAG has a draft or prerelease GitHub Release." >&2
+              exit 1
+            fi
+          fi
+
+          echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
+          echo "release_exists=$release_exists" >> "$GITHUB_OUTPUT"
+
+      - name: Download verified release assets
+        if: steps.revalidate.outputs.release_exists != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: final-release-assets
+          path: test-results/release-candidate
+
+      - name: Create immutable version tag
+        if: steps.revalidate.outputs.release_exists != 'true' && steps.revalidate.outputs.tag_exists != 'true'
+        shell: bash
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+          TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
           git config user.name 'github-actions[bot]'
@@ -205,12 +290,12 @@ jobs:
           git push origin "refs/tags/$TAG"
 
       - name: Publish final GitHub Release
-        if: steps.gate.outputs.release_exists != 'true'
+        if: steps.revalidate.outputs.release_exists != 'true'
         shell: bash
         env:
-          VERSION: ${{ steps.request.outputs.version }}
-          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
-          TAG: ${{ steps.request.outputs.tag }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
 
@@ -232,9 +317,9 @@ jobs:
         shell: bash
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          VERSION: ${{ steps.request.outputs.version }}
-          TAG: ${{ steps.request.outputs.tag }}
-          RELEASE_ALREADY_EXISTED: ${{ steps.gate.outputs.release_exists }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          RELEASE_ALREADY_EXISTED: ${{ steps.revalidate.outputs.release_exists }}
         run: |
           set -euo pipefail
           if [[ "$RELEASE_ALREADY_EXISTED" == "true" ]]; then
@@ -245,10 +330,28 @@ jobs:
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$message"
           gh issue close "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --reason completed
 
-      - name: Report failed issue-triggered release
+      - name: Report publication failure for issue trigger
         if: failure() && github.event_name == 'issues'
         shell: bash
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release workflow failed closed at a validation, test, tag, or release step. If the exact tag was created before a later GitHub Release API failure, the next retry will verify and reuse only that exact matching tag. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release publication failed closed after verification. If the exact tag was created before a later GitHub Release API failure, the next retry will verify and reuse only that exact matching tag. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."
+
+  report-verification-failure:
+    needs: verify
+    if: always() && needs.verify.result == 'failure' && github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Report fail-closed verification result
+        shell: bash
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release verification failed closed. No tag or GitHub Release was created by the publication job. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       target_sha:
-        description: 'Exact 40-character commit SHA; must equal current main'
+        description: 'Exact 40-character release commit SHA'
         required: true
         type: string
       confirm:
@@ -67,9 +67,7 @@ jobs:
       version: ${{ steps.request.outputs.version }}
       target_sha: ${{ steps.request.outputs.target_sha }}
       tag: ${{ steps.request.outputs.tag }}
-      tag_exists: ${{ steps.gate.outputs.tag_exists }}
       release_exists: ${{ steps.gate.outputs.release_exists }}
-      draft_exists: ${{ steps.gate.outputs.draft_exists }}
 
     steps:
       - name: Resolve release request
@@ -129,7 +127,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Validate release target and existing publication state
+      - name: Validate release target and publication state
         id: gate
         shell: bash
         env:
@@ -143,13 +141,34 @@ jobs:
           main_sha="$(git rev-parse origin/main)"
           checked_out_sha="$(git rev-parse HEAD)"
 
-          if [[ "$TARGET_SHA" != "$main_sha" ]]; then
-            echo "Refusing release: target SHA $TARGET_SHA is not current main $main_sha." >&2
-            exit 1
-          fi
           if [[ "$checked_out_sha" != "$TARGET_SHA" ]]; then
             echo "Refusing release: checkout drifted from requested target SHA." >&2
             exit 1
+          fi
+
+          if [[ "$TARGET_SHA" != "$main_sha" ]]; then
+            if ! git merge-base --is-ancestor "$TARGET_SHA" origin/main; then
+              echo "Refusing release: target $TARGET_SHA is neither current main nor its ancestor." >&2
+              exit 1
+            fi
+
+            identity_paths=(
+              package.json
+              package-lock.json
+              ghost-in-the-loop.user.js
+              extension/manifest.json
+              extension/content.js
+              extension/icon-48.png
+              extension/icon-96.png
+            )
+            for path in "${identity_paths[@]}"; do
+              target_blob="$(git rev-parse "$TARGET_SHA:$path")"
+              main_blob="$(git rev-parse "origin/main:$path")"
+              if [[ "$target_blob" != "$main_blob" ]]; then
+                echo "Refusing release: current main changed release-identity path $path after target $TARGET_SHA." >&2
+                exit 1
+              fi
+            done
           fi
 
           package_version="$(node -p "require('./package.json').version")"
@@ -177,12 +196,8 @@ jobs:
             fi
           done
 
-          tag_exists=false
           release_exists=false
-          draft_exists=false
-
           if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
-            tag_exists=true
             tag_sha="$(git rev-list -n 1 "$TAG")"
             if [[ "$tag_sha" != "$TARGET_SHA" ]]; then
               echo "Refusing release: existing $TAG points to $tag_sha, not $TARGET_SHA." >&2
@@ -199,16 +214,14 @@ jobs:
             if [[ "$draft" == "false" && "$prerelease" == "false" ]]; then
               release_exists=true
             elif [[ "$draft" == "true" && "$prerelease" == "false" && "$name" == "Ghost in the Loop $VERSION" && "$body" == *'<!-- gitl-final-release-bot -->'* ]]; then
-              draft_exists=true
+              :
             else
               echo "Refusing release: $TAG has a pre-existing Release not owned by the final-release bot." >&2
               exit 1
             fi
           fi
 
-          echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
           echo "release_exists=$release_exists" >> "$GITHUB_OUTPUT"
-          echo "draft_exists=$draft_exists" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         if: steps.gate.outputs.release_exists != 'true'
@@ -248,6 +261,7 @@ jobs:
     if: needs.verify.result == 'success'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       issues: write
     env:
@@ -260,7 +274,7 @@ jobs:
           ref: ${{ needs.verify.outputs.target_sha }}
           fetch-depth: 0
 
-      - name: Revalidate target immediately before publication
+      - name: Revalidate exact release identity before publication
         id: revalidate
         shell: bash
         env:
@@ -272,9 +286,30 @@ jobs:
 
           git fetch origin main --tags --force
           main_sha="$(git rev-parse origin/main)"
+
           if [[ "$TARGET_SHA" != "$main_sha" ]]; then
-            echo "Refusing publication: main moved from verified target $TARGET_SHA to $main_sha." >&2
-            exit 1
+            if ! git merge-base --is-ancestor "$TARGET_SHA" origin/main; then
+              echo "Refusing publication: target is no longer an ancestor of current main." >&2
+              exit 1
+            fi
+
+            identity_paths=(
+              package.json
+              package-lock.json
+              ghost-in-the-loop.user.js
+              extension/manifest.json
+              extension/content.js
+              extension/icon-48.png
+              extension/icon-96.png
+            )
+            for path in "${identity_paths[@]}"; do
+              target_blob="$(git rev-parse "$TARGET_SHA:$path")"
+              main_blob="$(git rev-parse "origin/main:$path")"
+              if [[ "$target_blob" != "$main_blob" ]]; then
+                echo "Refusing publication: main changed release-identity path $path after verification." >&2
+                exit 1
+              fi
+            done
           fi
 
           tag_exists=false
@@ -340,9 +375,7 @@ jobs:
           TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
-
           notes="$(printf '<!-- gitl-final-release-bot -->\nFinal public release of Ghost in the Loop %s.\n\nPublished from exact commit `%s` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented.' "$VERSION" "$TARGET_SHA")"
-
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --title "Ghost in the Loop $VERSION" \

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -1,0 +1,252 @@
+name: Publish Final Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version without v prefix (for example 8.8.0)'
+        required: true
+        type: string
+      target_sha:
+        description: 'Exact 40-character commit SHA; must equal current main'
+        required: true
+        type: string
+      confirm:
+        description: 'Type RELEASE to authorize tag and GitHub Release creation'
+        required: true
+        type: string
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: final-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'release-approved')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Resolve release request
+        id: request
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_TARGET_SHA: ${{ inputs.target_sha }}
+          DISPATCH_CONFIRM: ${{ inputs.confirm }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            version="$DISPATCH_VERSION"
+            target_sha="$DISPATCH_TARGET_SHA"
+            confirm="$DISPATCH_CONFIRM"
+          else
+            if [[ "$ISSUE_AUTHOR_ASSOCIATION" != "OWNER" ]]; then
+              echo "Release requests triggered from issues must be authored by the repository owner." >&2
+              exit 1
+            fi
+
+            version="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^version:[[:space:]]*//p')"
+            target_sha="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^target_sha:[[:space:]]*//p')"
+            confirm="$(printf '%s\n' "$ISSUE_BODY" | sed -n 's/^confirm:[[:space:]]*//p')"
+          fi
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "target_sha must be an exact lowercase 40-character Git commit SHA." >&2
+            exit 1
+          fi
+          if [[ "$confirm" != "RELEASE" ]]; then
+            echo "Release authorization missing: confirm must equal RELEASE." >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact release target
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.request.outputs.target_sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Validate release target and existing publication state
+        id: gate
+        shell: bash
+        env:
+          VERSION: ${{ steps.request.outputs.version }}
+          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
+          TAG: ${{ steps.request.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --tags --force
+          main_sha="$(git rev-parse origin/main)"
+          checked_out_sha="$(git rev-parse HEAD)"
+
+          if [[ "$TARGET_SHA" != "$main_sha" ]]; then
+            echo "Refusing release: target SHA $TARGET_SHA is not current main $main_sha." >&2
+            exit 1
+          fi
+          if [[ "$checked_out_sha" != "$TARGET_SHA" ]]; then
+            echo "Refusing release: checkout drifted from requested target SHA." >&2
+            exit 1
+          fi
+
+          package_version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').version")"
+          manifest_version="$(node -p "require('./extension/manifest.json').version")"
+          userscript_version="$(node - <<'NODE'
+          const fs = require('fs');
+          const text = fs.readFileSync('ghost-in-the-loop.user.js', 'utf8');
+          const match = text.match(/^\/\/\s*@version\s+([^\s]+)\s*$/m);
+          if (!match) process.exit(2);
+          process.stdout.write(match[1]);
+          NODE
+          )"
+
+          for pair in \
+            "package.json:$package_version" \
+            "package-lock.json:$lock_version" \
+            "extension/manifest.json:$manifest_version" \
+            "ghost-in-the-loop.user.js:$userscript_version"; do
+            file="${pair%%:*}"
+            observed="${pair#*:}"
+            if [[ "$observed" != "$VERSION" ]]; then
+              echo "Refusing release: $file reports $observed, expected $VERSION." >&2
+              exit 1
+            fi
+          done
+
+          tag_exists=false
+          release_exists=false
+
+          if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
+            tag_exists=true
+            tag_sha="$(git rev-list -n 1 "$TAG")"
+            if [[ "$tag_sha" != "$TARGET_SHA" ]]; then
+              echo "Refusing release: existing $TAG points to $tag_sha, not $TARGET_SHA." >&2
+              exit 1
+            fi
+          fi
+
+          if release_state="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv' 2>/dev/null)"; then
+            draft="${release_state%%$'\t'*}"
+            prerelease="${release_state#*$'\t'}"
+            if [[ "$draft" == "false" && "$prerelease" == "false" ]]; then
+              release_exists=true
+            else
+              echo "Refusing release: $TAG already has a draft or prerelease GitHub Release." >&2
+              exit 1
+            fi
+          fi
+
+          echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
+          echo "release_exists=$release_exists" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: steps.gate.outputs.release_exists != 'true'
+        run: npm ci
+
+      - name: Build and certify release payload
+        if: steps.gate.outputs.release_exists != 'true'
+        run: |
+          npm run cert:base
+          npm run lint
+          npm run test:unit
+          npm run identity:oracle
+          npm run package:oracle
+
+      - name: Install Playwright browsers
+        if: steps.gate.outputs.release_exists != 'true'
+        run: npx playwright install --with-deps chromium firefox
+
+      - name: Run browser safety tests
+        if: steps.gate.outputs.release_exists != 'true'
+        run: npm run test:e2e
+
+      - name: Create immutable version tag
+        if: steps.gate.outputs.release_exists != 'true' && steps.gate.outputs.tag_exists != 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.request.outputs.version }}
+          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
+          TAG: ${{ steps.request.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" "$TARGET_SHA" -m "Ghost in the Loop $VERSION"
+          git push origin "refs/tags/$TAG"
+
+      - name: Publish final GitHub Release
+        if: steps.gate.outputs.release_exists != 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.request.outputs.version }}
+          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
+          TAG: ${{ steps.request.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          notes="Final public release of Ghost in the Loop $VERSION.\n\nPublished from exact commit \`$TARGET_SHA\` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented."
+
+          gh release create "$TAG" \
+            test-results/release-candidate/ghost-in-the-loop.user.js \
+            test-results/release-candidate/SHA256SUMS \
+            test-results/release-candidate/package-manifest.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Ghost in the Loop $VERSION" \
+            --notes "$notes" \
+            --generate-notes \
+            --verify-tag \
+            --latest
+
+      - name: Report successful issue-triggered release
+        if: success() && github.event_name == 'issues'
+        shell: bash
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ steps.request.outputs.version }}
+          TAG: ${{ steps.request.outputs.tag }}
+          RELEASE_ALREADY_EXISTED: ${{ steps.gate.outputs.release_exists }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_ALREADY_EXISTED" == "true" ]]; then
+            message="Release $TAG already existed as a final release at the exact requested target; no publication change was needed."
+          else
+            message="Published final release $TAG (Ghost in the Loop $VERSION) after all release gates passed."
+          fi
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$message"
+          gh issue close "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --reason completed
+
+      - name: Report failed issue-triggered release
+        if: failure() && github.event_name == 'issues'
+        shell: bash
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release workflow failed closed. No further release action was attempted after the failing gate. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -69,6 +69,7 @@ jobs:
       tag: ${{ steps.request.outputs.tag }}
       tag_exists: ${{ steps.gate.outputs.tag_exists }}
       release_exists: ${{ steps.gate.outputs.release_exists }}
+      draft_exists: ${{ steps.gate.outputs.draft_exists }}
 
     steps:
       - name: Resolve release request
@@ -178,6 +179,7 @@ jobs:
 
           tag_exists=false
           release_exists=false
+          draft_exists=false
 
           if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
             tag_exists=true
@@ -188,19 +190,25 @@ jobs:
             fi
           fi
 
-          if release_state="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv' 2>/dev/null)"; then
-            draft="${release_state%%$'\t'*}"
-            prerelease="${release_state#*$'\t'}"
+          if release_json="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,name,body 2>/dev/null)"; then
+            draft="$(printf '%s' "$release_json" | jq -r '.isDraft')"
+            prerelease="$(printf '%s' "$release_json" | jq -r '.isPrerelease')"
+            name="$(printf '%s' "$release_json" | jq -r '.name')"
+            body="$(printf '%s' "$release_json" | jq -r '.body')"
+
             if [[ "$draft" == "false" && "$prerelease" == "false" ]]; then
               release_exists=true
+            elif [[ "$draft" == "true" && "$prerelease" == "false" && "$name" == "Ghost in the Loop $VERSION" && "$body" == *'<!-- gitl-final-release-bot -->'* ]]; then
+              draft_exists=true
             else
-              echo "Refusing release: $TAG already has a draft or prerelease GitHub Release." >&2
+              echo "Refusing release: $TAG has a pre-existing Release not owned by the final-release bot." >&2
               exit 1
             fi
           fi
 
           echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
           echo "release_exists=$release_exists" >> "$GITHUB_OUTPUT"
+          echo "draft_exists=$draft_exists" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         if: steps.gate.outputs.release_exists != 'true'
@@ -256,6 +264,7 @@ jobs:
         id: revalidate
         shell: bash
         env:
+          VERSION: ${{ needs.verify.outputs.version }}
           TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
           TAG: ${{ needs.verify.outputs.tag }}
         run: |
@@ -270,6 +279,7 @@ jobs:
 
           tag_exists=false
           release_exists=false
+          draft_exists=false
 
           if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
             tag_exists=true
@@ -280,19 +290,25 @@ jobs:
             fi
           fi
 
-          if release_state="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv' 2>/dev/null)"; then
-            draft="${release_state%%$'\t'*}"
-            prerelease="${release_state#*$'\t'}"
+          if release_json="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,name,body 2>/dev/null)"; then
+            draft="$(printf '%s' "$release_json" | jq -r '.isDraft')"
+            prerelease="$(printf '%s' "$release_json" | jq -r '.isPrerelease')"
+            name="$(printf '%s' "$release_json" | jq -r '.name')"
+            body="$(printf '%s' "$release_json" | jq -r '.body')"
+
             if [[ "$draft" == "false" && "$prerelease" == "false" ]]; then
               release_exists=true
+            elif [[ "$draft" == "true" && "$prerelease" == "false" && "$name" == "Ghost in the Loop $VERSION" && "$body" == *'<!-- gitl-final-release-bot -->'* ]]; then
+              draft_exists=true
             else
-              echo "Refusing publication: $TAG has a draft or prerelease GitHub Release." >&2
+              echo "Refusing publication: $TAG has a pre-existing Release not owned by the final-release bot." >&2
               exit 1
             fi
           fi
 
           echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
           echo "release_exists=$release_exists" >> "$GITHUB_OUTPUT"
+          echo "draft_exists=$draft_exists" >> "$GITHUB_OUTPUT"
 
       - name: Download verified release assets
         if: steps.revalidate.outputs.release_exists != 'true'
@@ -315,8 +331,8 @@ jobs:
           git tag -a "$TAG" "$TARGET_SHA" -m "Ghost in the Loop $VERSION"
           git push origin "refs/tags/$TAG"
 
-      - name: Publish final GitHub Release
-        if: steps.revalidate.outputs.release_exists != 'true'
+      - name: Create resumable draft GitHub Release
+        if: steps.revalidate.outputs.release_exists != 'true' && steps.revalidate.outputs.draft_exists != 'true'
         shell: bash
         env:
           VERSION: ${{ needs.verify.outputs.version }}
@@ -325,18 +341,38 @@ jobs:
         run: |
           set -euo pipefail
 
-          notes="$(printf 'Final public release of Ghost in the Loop %s.\n\nPublished from exact commit `%s` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented.' "$VERSION" "$TARGET_SHA")"
+          notes="$(printf '<!-- gitl-final-release-bot -->\nFinal public release of Ghost in the Loop %s.\n\nPublished from exact commit `%s` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented.' "$VERSION" "$TARGET_SHA")"
 
           gh release create "$TAG" \
-            test-results/release-candidate/ghost-in-the-loop.user.js \
-            test-results/release-candidate/SHA256SUMS \
-            test-results/release-candidate/package-manifest.json \
             --repo "$GITHUB_REPOSITORY" \
             --title "Ghost in the Loop $VERSION" \
             --notes "$notes" \
             --generate-notes \
             --verify-tag \
-            --latest
+            --draft
+
+      - name: Upload certified release assets
+        if: steps.revalidate.outputs.release_exists != 'true'
+        shell: bash
+        env:
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            test-results/release-candidate/ghost-in-the-loop.user.js \
+            test-results/release-candidate/SHA256SUMS \
+            test-results/release-candidate/package-manifest.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Publish final GitHub Release
+        if: steps.revalidate.outputs.release_exists != 'true'
+        shell: bash
+        env:
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
 
       - name: Report successful issue-triggered release
         if: success() && github.event_name == 'issues'
@@ -362,7 +398,7 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release publication failed closed after verification. If the exact tag was created before a later GitHub Release API failure, the next retry will verify and reuse only that exact matching tag. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release publication failed closed after verification. An exact bot-owned draft and/or exact tag may remain so the next retry can safely resume after revalidation. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."
 
   report-verification-failure:
     needs: verify

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -43,12 +43,18 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          RUN_REF: ${{ github.ref }}
           DISPATCH_VERSION: ${{ inputs.version }}
           DISPATCH_TARGET_SHA: ${{ inputs.target_sha }}
           DISPATCH_CONFIRM: ${{ inputs.confirm }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           set -euo pipefail
+
+          if [[ "$RUN_REF" != "refs/heads/main" ]]; then
+            echo "Release automation must execute from the main workflow definition; got $RUN_REF." >&2
+            exit 1
+          fi
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             version="$DISPATCH_VERSION"
@@ -208,7 +214,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          notes="Final public release of Ghost in the Loop $VERSION.\n\nPublished from exact commit \`$TARGET_SHA\` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented."
+          notes="$(printf 'Final public release of Ghost in the Loop %s.\n\nPublished from exact commit `%s` after the repository certification, unit, BUILD-IDENTITY, package/checksum, Chromium, and Firefox safety gates passed. Release claims remain bounded to evidence in this commit; no store or physical-device certification is implied unless explicitly documented.' "$VERSION" "$TARGET_SHA")"
 
           gh release create "$TAG" \
             test-results/release-candidate/ghost-in-the-loop.user.js \
@@ -245,4 +251,4 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release workflow failed closed. No further release action was attempted after the failing gate. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Final release workflow failed closed at a validation, test, tag, or release step. If the exact tag was created before a later GitHub Release API failure, the next retry will verify and reuse only that exact matching tag. Inspect Actions run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID before retrying."

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -5,17 +5,21 @@ Ghost in the Loop uses a fail-closed GitHub Actions workflow for final public re
 - workflow: `.github/workflows/publish-final-release.yml`
 - final tag format: `vX.Y.Z`
 - final release title: `Ghost in the Loop X.Y.Z`
-- target must be the exact current `main` commit
+- the requested target is normally the exact current `main` commit
+- an older target is allowed only when it is an ancestor of current `main` and every release-identity path is byte-for-byte unchanged on current `main`
+- release-identity paths are `package.json`, `package-lock.json`, the userscript, generated extension manifest/content, and both shipped icons
 - package, lockfile, userscript, and extension manifest versions must all equal `X.Y.Z`
-- repository certification, lint, unit tests, BUILD-IDENTITY, package/checksum verification, Chromium, and Firefox E2E safety tests must all pass before publication
+- repository certification, lint, unit tests, BUILD-IDENTITY, package/checksum verification, Chromium, and Firefox E2E safety tests must all pass on the exact requested target before publication
 - verification and dependency/test execution run with read-only repository contents permission
 - the write-capable token exists only in a separate post-verification publication job
-- the publication job re-checks that `main` still points to the exact verified SHA before any tag or Release write
+- the publication job repeats the target/ancestor/payload-identity checks immediately before any tag or Release write
 - the workflow will not move an existing mismatched tag
 - an existing exact matching tag may be reused only when recovering from a later GitHub Release API failure
 - publication uses a bot-marked draft Release, uploads the verified assets, and only then publishes the final Release
 - a bot-marked draft may be resumed after a failed upload/API attempt; unrelated drafts and prereleases fail closed
 - release assets include the certified userscript, `SHA256SUMS`, and `package-manifest.json`
+
+The ancestor rule exists for a narrow but important case: release-process documentation or automation may land on `main` after a product commit has already been certified. The older product commit may still be tagged exactly, but only while every shipped/version identity path remains identical. Any release-payload drift closes that path automatically.
 
 ## ChatGPT / GitHub connector path
 
@@ -35,7 +39,7 @@ target_sha: 0123456789abcdef0123456789abcdef01234567
 confirm: RELEASE
 ```
 
-The `target_sha` must be the full 40-character lowercase SHA of the current `main` head. Opening the issue is the publication trigger; there is no separate label step.
+`target_sha` is the full 40-character lowercase SHA that should receive the immutable version tag. The workflow verifies that it is either current `main`, or an ancestor whose complete release identity is still byte-identical to current `main`. Opening the issue is the publication trigger; there is no separate label step.
 
 On success, the workflow creates the immutable tag, publishes the normal final GitHub Release, comments on the issue, and closes it. On failure, it comments with the Actions run and leaves the issue open for investigation.
 
@@ -44,16 +48,16 @@ On success, the workflow creates the immutable tag, publishes the normal final G
 The same workflow supports `workflow_dispatch`. Run it only from `main` and provide:
 
 - `version`: semantic version without the `v` prefix
-- `target_sha`: exact current `main` SHA
+- `target_sha`: exact release commit SHA
 - `confirm`: `RELEASE`
 
-Selecting any ref other than `main` fails closed.
+Selecting any workflow ref other than `main` fails closed.
 
 ## MCP integration contract
 
 A future custom ChatGPT MCP app does not need direct Git-tag or Release mutation if it can invoke this repository-controlled release path. The smallest useful MCP surface is:
 
-1. read current `main` SHA;
+1. read current `main` SHA and the intended exact release SHA;
 2. read package/userscript version;
 3. create the owner release-request issue above, or dispatch `Publish Final Release` on `main`;
 4. read the resulting Actions run;

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -13,7 +13,8 @@ Ghost in the Loop uses a fail-closed GitHub Actions workflow for final public re
 - the publication job re-checks that `main` still points to the exact verified SHA before any tag or Release write
 - the workflow will not move an existing mismatched tag
 - an existing exact matching tag may be reused only when recovering from a later GitHub Release API failure
-- a pre-existing draft or prerelease blocks the final-release workflow
+- publication uses a bot-marked draft Release, uploads the verified assets, and only then publishes the final Release
+- a bot-marked draft may be resumed after a failed upload/API attempt; unrelated drafts and prereleases fail closed
 - release assets include the certified userscript, `SHA256SUMS`, and `package-manifest.json`
 
 ## ChatGPT / GitHub connector path

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -1,0 +1,62 @@
+# Final Release Automation
+
+Ghost in the Loop uses a fail-closed GitHub Actions workflow for final public releases:
+
+- workflow: `.github/workflows/publish-final-release.yml`
+- final tag format: `vX.Y.Z`
+- final release title: `Ghost in the Loop X.Y.Z`
+- target must be the exact current `main` commit
+- package, lockfile, userscript, and extension manifest versions must all equal `X.Y.Z`
+- repository certification, lint, unit tests, BUILD-IDENTITY, package/checksum verification, Chromium, and Firefox E2E safety tests must all pass before publication
+- the workflow will not move an existing mismatched tag
+- an existing exact matching tag may be reused only when recovering from a later GitHub Release API failure
+- a pre-existing draft or prerelease blocks the final-release workflow
+- release assets include the certified userscript, `SHA256SUMS`, and `package-manifest.json`
+
+## ChatGPT / GitHub connector path
+
+The workflow deliberately supports an owner-authored GitHub issue as a release request. This allows a connected ChatGPT GitHub client that can create issues, but cannot directly create Git tags or GitHub Releases, to complete the release end-to-end through repository automation.
+
+Create an issue whose title begins exactly with:
+
+```text
+[release-final]
+```
+
+The issue must be authored by the repository owner and its body must contain exactly one line for each field:
+
+```text
+version: 8.8.0
+target_sha: 0123456789abcdef0123456789abcdef01234567
+confirm: RELEASE
+```
+
+The `target_sha` must be the full 40-character lowercase SHA of the current `main` head. Opening the issue is the publication trigger; there is no separate label step.
+
+On success, the workflow creates the immutable tag, publishes the normal final GitHub Release, comments on the issue, and closes it. On failure, it comments with the Actions run and leaves the issue open for investigation.
+
+## Manual fallback
+
+The same workflow supports `workflow_dispatch`. Run it only from `main` and provide:
+
+- `version`: semantic version without the `v` prefix
+- `target_sha`: exact current `main` SHA
+- `confirm`: `RELEASE`
+
+Selecting any ref other than `main` fails closed.
+
+## MCP integration contract
+
+A future custom ChatGPT MCP app does not need direct Git-tag or Release mutation if it can invoke this repository-controlled release path. The smallest useful MCP surface is:
+
+1. read current `main` SHA;
+2. read package/userscript version;
+3. create the owner release-request issue above, or dispatch `Publish Final Release` on `main`;
+4. read the resulting Actions run;
+5. read the final tag and GitHub Release.
+
+Keeping the safety policy in the repository is preferable to duplicating release logic inside each external client. The MCP client should request a release; the repository workflow remains the authority that validates and publishes it.
+
+## Scope boundary
+
+This workflow publishes the Git tag, GitHub Release, and listed release assets only. It does not publish browser-store packages, change extension-store channels, or certify physical devices. Those remain separate actions when applicable.

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -8,6 +8,9 @@ Ghost in the Loop uses a fail-closed GitHub Actions workflow for final public re
 - target must be the exact current `main` commit
 - package, lockfile, userscript, and extension manifest versions must all equal `X.Y.Z`
 - repository certification, lint, unit tests, BUILD-IDENTITY, package/checksum verification, Chromium, and Firefox E2E safety tests must all pass before publication
+- verification and dependency/test execution run with read-only repository contents permission
+- the write-capable token exists only in a separate post-verification publication job
+- the publication job re-checks that `main` still points to the exact verified SHA before any tag or Release write
 - the workflow will not move an existing mismatched tag
 - an existing exact matching tag may be reused only when recovering from a later GitHub Release API failure
 - a pre-existing draft or prerelease blocks the final-release workflow


### PR DESCRIPTION
Adds a repository-native final-release workflow so future ChatGPT/GitHub sessions can publish tags and GitHub Releases without requiring direct tag/release connector actions.

Key properties:
- manual `workflow_dispatch` fallback;
- owner-authored `[release-final]` issue trigger that the existing GitHub connector can create;
- exact release SHA required; normally current `main`, with an older ancestor accepted only while package/lock/userscript/generated-extension/icon release identity remains byte-for-byte unchanged on `main`;
- version coherence across package, lockfile, userscript, and extension manifest;
- full certification/lint/unit/BUILD-IDENTITY/package oracle plus Chromium+Firefox E2E before publication;
- verification/tests run with read-only repository permission;
- write authority exists only in a separate post-verification publication job and the release identity is revalidated immediately before writes;
- immutable `vX.Y.Z` tag creation;
- resumable bot-owned draft followed by certified asset upload and normal final GitHub Release publication;
- no store publication or physical-device certification claim.

Also documents the minimal MCP integration contract. No product/runtime bytes are changed by this PR.

Do not use this PR itself as a release request. After merge and CI, a separate owner-authored `[release-final]` issue is the publication trigger.