### PR TITLE
8.8.1 — ChatGPT Send compatibility + exact-one authority hardening

### DIFF
--- a/.gitl/evidence/round-7/candidate-identity.json
+++ b/.gitl/evidence/round-7/candidate-identity.json
@@ -4,7 +4,7 @@
   "releaseTarget": "8.8.1",
   "provenance": {
     "branch": "agent/8.8-repair-resume",
-    "head": "3995091091fa2a1a2d66dec3ef4a965c2b2dbbe8"
+    "head": "e6e775bd1c989a0df7cffce024504f2237f5afd5"
   },
   "channels": {
     "candidate": "agent/8.8-repair-resume",
@@ -34,8 +34,8 @@
   "payload": [
     {
       "path": "ghost-in-the-loop.user.js",
-      "bytes": 376272,
-      "sha256": "22e32adb53abc6a7b46e46f7fa12746687c0c1381a14f71dc1ef27dfe4c44c42"
+      "bytes": 376367,
+      "sha256": "fa08580b4cfc55e3b210bf38d8eaf02d1f33f98c14faab974dfa355fb202d274"
     },
     {
       "path": "extension/manifest.json",
@@ -44,8 +44,8 @@
     },
     {
       "path": "extension/content.js",
-      "bytes": 375413,
-      "sha256": "468b660b52ccc9750780bea46dbd0752efc13798902f77c6ca72fca2b0a925c7"
+      "bytes": 375508,
+      "sha256": "b492d7e65ab97d4450af2cdc84cfa9522b47977eba146485c2fdb3edf44d4080"
     },
     {
       "path": "extension/icon-48.png",

--- a/.gitl/evidence/round-7/candidate-identity.json
+++ b/.gitl/evidence/round-7/candidate-identity.json
@@ -1,27 +1,27 @@
 {
   "schema": "gitl-build-identity-v1",
   "repository": "MShneur/ghost-in-the-loop",
-  "releaseTarget": "8.8.0",
+  "releaseTarget": "8.8.1",
   "provenance": {
     "branch": "agent/8.8-repair-resume",
-    "head": "30c49f690afb14683014e0a7c40c5c2093aaba2a"
+    "head": "937d0c9e23a3ef105be2e52f64a227b136e220df"
   },
   "channels": {
     "candidate": "agent/8.8-repair-resume",
     "stable": "main",
     "stableUserscriptUpdateUrl": "https://raw.githubusercontent.com/MShneur/ghost-in-the-loop/main/ghost-in-the-loop.user.js",
     "stableUserscriptDownloadUrl": "https://raw.githubusercontent.com/MShneur/ghost-in-the-loop/main/ghost-in-the-loop.user.js",
-    "stableVersionObserved": "8.7.1",
+    "stableVersionObserved": null,
     "publicationState": "candidate-not-published",
     "publishReady": false
   },
   "versions": {
-    "package": "8.8.0",
-    "packageLock": "8.8.0",
-    "packageLockRoot": "8.8.0",
-    "userscriptHeader": "8.8.0",
-    "runtime": "8.8.0",
-    "manifest": "8.8.0"
+    "package": "8.8.1",
+    "packageLock": "8.8.1",
+    "packageLockRoot": "8.8.1",
+    "userscriptHeader": "8.8.1",
+    "runtime": "8.8.1",
+    "manifest": "8.8.1"
   },
   "contracts": {
     "canonicalSource": "ghost-in-the-loop.user.js",
@@ -34,18 +34,18 @@
   "payload": [
     {
       "path": "ghost-in-the-loop.user.js",
-      "bytes": 375302,
-      "sha256": "3493ccc31c97db9749768ab32fafc6dc89c2ebc23f043ebaf998aaf115ebf1df"
+      "bytes": 376092,
+      "sha256": "3c56f10f355a83521c444d09283a346e1bd2bf16f968ceddb449784b8ceb3095"
     },
     {
       "path": "extension/manifest.json",
       "bytes": 1589,
-      "sha256": "1bd616e74988e820885ab210ade3afb031eb905bd522053768dae58650292489"
+      "sha256": "15ebec0ed751ed17a87b140bdcef22276a1e4b393ce636116914002ff1a33c38"
     },
     {
       "path": "extension/content.js",
-      "bytes": 374443,
-      "sha256": "2570d6f6e735ad9ecd0eb49a608c7fd36c79c1b0ed70c5fbf367fac8dadd6990"
+      "bytes": 375233,
+      "sha256": "73222694ea0b8ee5cd9f56af203dc83002408c54262cdeea3208c98071e579c8"
     },
     {
       "path": "extension/icon-48.png",

--- a/.gitl/evidence/round-7/candidate-identity.json
+++ b/.gitl/evidence/round-7/candidate-identity.json
@@ -4,7 +4,7 @@
   "releaseTarget": "8.8.1",
   "provenance": {
     "branch": "agent/8.8-repair-resume",
-    "head": "937d0c9e23a3ef105be2e52f64a227b136e220df"
+    "head": "3995091091fa2a1a2d66dec3ef4a965c2b2dbbe8"
   },
   "channels": {
     "candidate": "agent/8.8-repair-resume",
@@ -34,8 +34,8 @@
   "payload": [
     {
       "path": "ghost-in-the-loop.user.js",
-      "bytes": 376092,
-      "sha256": "3c56f10f355a83521c444d09283a346e1bd2bf16f968ceddb449784b8ceb3095"
+      "bytes": 376272,
+      "sha256": "22e32adb53abc6a7b46e46f7fa12746687c0c1381a14f71dc1ef27dfe4c44c42"
     },
     {
       "path": "extension/manifest.json",
@@ -44,8 +44,8 @@
     },
     {
       "path": "extension/content.js",
-      "bytes": 375233,
-      "sha256": "73222694ea0b8ee5cd9f56af203dc83002408c54262cdeea3208c98071e579c8"
+      "bytes": 375413,
+      "sha256": "468b660b52ccc9750780bea46dbd0752efc13798902f77c6ca72fca2b0a925c7"
     },
     {
       "path": "extension/icon-48.png",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,42 @@
 # Changelog
 
 
+## [8.8.1] — ChatGPT live-send repair (reviewed "Send message" identity)
+
+Field regression on real ChatGPT after 8.8.0: Ghost inserted the continuation
+text into the composer but it never sent, and Ghost-owned controls appeared to
+jump the page toward the top.
+
+- **Send never fires (primary):** current ChatGPT labels its composer Send
+  control `aria-label="Send message"`, which the 8.8.0 reviewed selector list
+  did not include. `_reviewedSend()` returned null, `engineSend` fell to the
+  reviewed synthetic-Enter fallback, and current ChatGPT ignored the synthetic
+  key event. Added `button[aria-label="Send message"]` as the first reviewed
+  ChatGPT Send selector, so the real button resolves as a **single reviewed
+  actuator** (one click) and the Enter fallback is not reached. Exact-identity,
+  uniqueness (fail-closed on ambiguity), disabled/`aria-disabled` rejection,
+  `aria-haspopup`/`aria-expanded` structural veto and `SEND_VETO` are all
+  preserved; at-most-once dispatch is unchanged.
+- **Jump-to-top (defensive):** `mountPanel` now installs one panel-scoped,
+  capture-phase guard that cancels only the browser's default action on Ghost
+  button clicks (host-form submit / anchor navigation). It does not
+  `stopPropagation`, so Ghost's own handlers still run, and it covers every
+  button across re-renders. Duck-typed (`el.closest`) so it is safe in
+  userscript sandboxes that don't expose `Element` globally.
+- Regression coverage: `tests/chatgpt-send-selector.test.js` (source contract,
+  live `_reviewedSend()` resolution, ambiguity/disabled/decoy fail-closed, and
+  the panel guard contract). The diagnostic field shim
+  `diagnostics/gitl-chatgpt-8.8-hotfix.user.js` is superseded by this production
+  repair.
+
+**Live-certification boundary:** this repair is backed by deterministic tests
+and strong converging DOM evidence (independent multi-model review, the in-repo
+test fixture, the Gemini adapter's own use of the identity, and an external
+ChatGPT userscript). It was **not** verified against an authenticated live
+ChatGPT session in this environment (no live browser carrier was available).
+Live ChatGPT actuation remains a required release gate — see
+`docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md`.
+
 ## [8.8.0] — workflow-neutral controls and explicit decisions
 
 - Fixed false COMPOSER-002 pauses for complete multiline prompts in block-structured contenteditable editors by verifying rendered semantic text while retaining exact normalized staging checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,41 @@
 # Changelog
 
 
-## [8.8.1] — ChatGPT live-send repair (reviewed "Send message" identity)
+## [8.8.1] — ChatGPT send compatibility candidate and authority hardening
 
 Field regression on real ChatGPT after 8.8.0: Ghost inserted the continuation
 text into the composer but it never sent, and Ghost-owned controls appeared to
 jump the page toward the top.
 
-- **Send never fires (primary):** current ChatGPT labels its composer Send
-  control `aria-label="Send message"`, which the 8.8.0 reviewed selector list
-  did not include. `_reviewedSend()` returned null, `engineSend` fell to the
-  reviewed synthetic-Enter fallback, and current ChatGPT ignored the synthetic
-  key event. Added `button[aria-label="Send message"]` as the first reviewed
-  ChatGPT Send selector, so the real button resolves as a **single reviewed
-  actuator** (one click) and the Enter fallback is not reached. Exact-identity,
-  uniqueness (fail-closed on ambiguity), disabled/`aria-disabled` rejection,
-  `aria-haspopup`/`aria-expanded` structural veto and `SEND_VETO` are all
-  preserved; at-most-once dispatch is unchanged.
-- **Jump-to-top (defensive):** `mountPanel` now installs one panel-scoped,
-  capture-phase guard that cancels only the browser's default action on Ghost
-  button clicks (host-form submit / anchor navigation). It does not
-  `stopPropagation`, so Ghost's own handlers still run, and it covers every
-  button across re-renders. Duck-typed (`el.closest`) so it is safe in
-  userscript sandboxes that don't expose `Element` globally.
-- Regression coverage: `tests/chatgpt-send-selector.test.js` (source contract,
-  live `_reviewedSend()` resolution, ambiguity/disabled/decoy fail-closed, and
-  the panel guard contract). The diagnostic field shim
-  `diagnostics/gitl-chatgpt-8.8-hotfix.user.js` is superseded by this production
-  repair.
+- **Bounded Send compatibility:** added
+  `button[aria-label="Send message"]` to ChatGPT's reviewed selector set. This
+  covers a plausible host variant without changing the one-actuator transaction
+  model. It is not claimed as the proven field root cause: a current signed-out
+  public ChatGPT probe instead exposed `#composer-submit-button` with
+  `aria-label="Send prompt"` and `data-testid="send-button"`, both already
+  covered by 8.8.0. The failing authenticated layout remains unobserved.
+- **Global ambiguity rejection:** `_reviewedSend()` now deduplicates aliases for
+  the same DOM node across the complete reviewed selector set and returns an
+  actuator only when that union contains exactly one node. Previously, two
+  plausible controls could bypass fail-closed behavior when a later selector
+  happened to match only one of them.
+- **Ghost control semantics:** every rendered Ghost button is explicitly
+  normalized to `type="button"`. The earlier candidate's global click
+  `preventDefault()` guard was removed: `#gitl` mounts directly under `body`, so
+  no ChatGPT form/anchor ancestry was demonstrated, and intercepting every click
+  did not establish the scroll-jump root cause.
+- Regression coverage now includes exact-node alias deduplication, cross-selector
+  ambiguity, disabled/menu/disclosure decoys, hidden and replaced Send nodes,
+  the observed signed-out public composer shape, and a real-browser fixture for
+  Ghost state changes with no host form submission, URL/hash mutation, Send
+  click, or scroll movement. The diagnostic field shim remains a temporary
+  probe, not production architecture.
 
-**Live-certification boundary:** this repair is backed by deterministic tests
-and strong converging DOM evidence (independent multi-model review, the in-repo
-test fixture, the Gemini adapter's own use of the identity, and an external
-ChatGPT userscript). It was **not** verified against an authenticated live
-ChatGPT session in this environment (no live browser carrier was available).
-Live ChatGPT actuation remains a required release gate — see
+**Live-certification boundary:** this candidate is backed by deterministic tests
+and a read-only signed-out public DOM inspection. It was **not** verified against
+an authenticated live ChatGPT session and must not be described as a proven
+field repair or live-certified release. Live ChatGPT actuation remains a required
+release gate — see
 `docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md`.
 
 ## [8.8.0] — workflow-neutral controls and explicit decisions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,23 @@ jump the page toward the top.
   `aria-label="Send prompt"` and `data-testid="send-button"`, both already
   covered by 8.8.0. The failing authenticated layout remains unobserved.
 - **Global ambiguity rejection:** `_reviewedSend()` now deduplicates aliases for
-  the same DOM node across the complete reviewed selector set and returns an
-  actuator only when that union contains exactly one node. Previously, two
-  plausible controls could bypass fail-closed behavior when a later selector
-  happened to match only one of them.
+  the same DOM node across the complete reviewed-selector and human-taught
+  authority union, and returns an actuator only when that union contains exactly
+  one node. Previously, two plausible controls could bypass fail-closed behavior
+  when a later selector happened to match only one of them; a taught selector
+  that drifted to multiple live controls could also return its first match.
 - **Ghost control semantics:** every rendered Ghost button is explicitly
   normalized to `type="button"`. The earlier candidate's global click
   `preventDefault()` guard was removed: `#gitl` mounts directly under `body`, so
   no ChatGPT form/anchor ancestry was demonstrated, and intercepting every click
   did not establish the scroll-jump root cause.
 - Regression coverage now includes exact-node alias deduplication, cross-selector
-  ambiguity, disabled/menu/disclosure decoys, hidden and replaced Send nodes,
-  the observed signed-out public composer shape, and a real-browser fixture for
-  Ghost state changes with no host form submission, URL/hash mutation, Send
-  click, or scroll movement. The diagnostic field shim remains a temporary
-  probe, not production architecture.
+  and taught-selector ambiguity, disabled/menu/disclosure decoys, hidden and
+  replaced Send nodes, the observed signed-out public composer shape, and
+  real-browser fixtures for taught-selector drift plus Ghost state changes with
+  no host form submission, URL/hash mutation, Send click, or scroll movement.
+  The diagnostic field shim remains a temporary probe, not production
+  architecture.
 
 **Live-certification boundary:** this candidate is backed by deterministic tests
 and a read-only signed-out public DOM inspection. It was **not** verified against

--- a/diagnostics/gitl-chatgpt-8.8-hotfix.user.js
+++ b/diagnostics/gitl-chatgpt-8.8-hotfix.user.js
@@ -1,0 +1,94 @@
+// ==UserScript==
+// @name         Ghost in the Loop 8.8 ChatGPT Live Hotfix
+// @namespace    https://github.com/MShneur/ghost-in-the-loop
+// @version      8.8.0-hotfix.1
+// @description  Temporary ChatGPT field hotfix for Ghost 8.8.0: semantic Send substitution and Ghost-button default-action guard.
+// @match        https://chatgpt.com/*
+// @match        https://chat.openai.com/*
+// @run-at       document-start
+// @noframes
+// @grant        none
+// @license      AGPL-3.0
+// ==/UserScript==
+
+(() => {
+  'use strict';
+
+  const SEND_SELECTORS = [
+    'button[data-testid="send-button"]',
+    'button[aria-label="Send prompt"]',
+    'button[aria-label="Send"]',
+    'button[aria-label="Send message"]',
+    'button[aria-label^="Send "]',
+    'button[data-testid*="send"]',
+    'button[data-testid*="submit"]'
+  ];
+
+  const VETO = /stop|voice|mic|microphone|attach|upload|tool|model|picker|dropdown|emoji|format|cancel/i;
+
+  function visible(el) {
+    if (!(el instanceof Element)) return false;
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && cs.display !== 'none' && cs.visibility !== 'hidden';
+  }
+
+  function safeSend(el) {
+    if (!(el instanceof HTMLButtonElement)) return false;
+    if (el.disabled || el.getAttribute('aria-disabled') === 'true') return false;
+    if (el.hasAttribute('aria-haspopup') || el.getAttribute('aria-expanded') === 'true') return false;
+    const surface = [el.id, el.getAttribute('aria-label'), el.getAttribute('data-testid'), el.textContent]
+      .filter(Boolean).join(' ');
+    return !VETO.test(surface) && visible(el);
+  }
+
+  function isChatComposer(el) {
+    if (!(el instanceof Element)) return false;
+    return el.matches('#prompt-textarea, div[contenteditable="true"][id="prompt-textarea"], textarea[data-id="root"], textarea');
+  }
+
+  function findUniqueSend(composer) {
+    const roots = [];
+    const form = composer.closest('form');
+    if (form) roots.push(form);
+    const composerRoot = composer.closest('[data-testid="composer"], [class*="composer"], main');
+    if (composerRoot && !roots.includes(composerRoot)) roots.push(composerRoot);
+    roots.push(document);
+
+    for (const root of roots) {
+      const found = [];
+      for (const sel of SEND_SELECTORS) {
+        for (const el of root.querySelectorAll(sel)) {
+          if (safeSend(el) && !found.includes(el)) found.push(el);
+        }
+      }
+      if (found.length === 1) return found[0];
+      if (found.length > 1) return null;
+    }
+    return null;
+  }
+
+  // Ghost 8.8 emits exactly one synthetic Enter when its reviewed ChatGPT
+  // button selectors do not resolve. On current ChatGPT builds the real Send
+  // control may be semantically labelled "Send message" instead. Intercept the
+  // synthetic Enter in capture phase before ChatGPT sees it, and substitute one
+  // exact button click only when a unique safe semantic Send exists.
+  document.addEventListener('keydown', (event) => {
+    if (event.isTrusted || event.key !== 'Enter' || !document.getElementById('gitl')) return;
+    const composer = event.target;
+    if (!isChatComposer(composer)) return;
+    const send = findUniqueSend(composer);
+    if (!send) return; // fail closed: leave Ghost's original reviewed Enter path untouched
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    send.click();
+  }, true);
+
+  // Ghost controls are transport/configuration controls, never host-form
+  // submitters. Cancel any host default action while preserving Ghost's own
+  // bubbling handlers. This guards the reported jump-to-page-top behavior.
+  document.addEventListener('click', (event) => {
+    const button = event.target instanceof Element ? event.target.closest('#gitl button') : null;
+    if (button) event.preventDefault();
+  }, true);
+})();

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -185,70 +185,120 @@ The most valuable next step is independent reproduction and repair of the produc
 
 ---
 
-## Independent takeover — production repair (8.8.1)
+## Independent takeover correction (2026-08-12)
 
-A second worker independently reviewed the branch, PR #36, current `main@8.8.0`,
-the diagnostic shim, and the multi-agent field reviews, then reconciled against
-the Personal-Forge Ghost coordination record (post-release takeover handoff:
-8.8 on stable channel; preserve exact reviewed Send identity, at-most-once
-dispatch, CHOICE/route/lease/uncertainty; native takeover is future work).
+A subsequent independent sweep reconciled the repository, PR #36, CI, the
+attached multi-pass review, `.gitl` state, and the canonical Personal Forge
+coordination record. Only non-sensitive coordination conclusions are recorded
+here: 8.8.0 is already on the stable channel; this work remains a narrow hotfix;
+exact Send identity, at-most-once dispatch, CHOICE, route/lease and uncertainty
+gates remain mandatory; native-site takeover is a separate future stream.
 
-### Reproduced deterministically
-- `main@8.8.0` ChatGPT adapter `send` list does **not** contain
-  `button[aria-label="Send message"]`; `pressEnter()` has **no callers** in the
-  send path (the single-dispatch `reviewed-enter` strategy fires one inline
-  `keydown`, so the reports' `pressEnter` concern is moot for the transaction).
-- The failure chain is therefore: inject Continue → `_reviewedSend()` returns
-  null (no reviewed identity matches the live control) → `engineSend` selects
-  the reviewed synthetic-Enter fallback → current ChatGPT ignores the synthetic
-  key → text remains in the composer. This matches the field report exactly.
+### GitHub state at takeover
 
-### Evidence for `aria-label="Send message"` (no authenticated live capture available)
-Converging, non-authenticated: the repo's own test fixture, the Gemini adapter's
-existing use of the identity, multiple independent multi-model reviews, and an
-external maintained ChatGPT userscript all cite `aria-label="Send message"` as
-the current live composer Send control. The connected browser carrier was
-unavailable, so exact authenticated-live DOM remains **UNVERIFIED**.
+- `main` remained `3fa1ad3ec6bef342260864f28693331b4f3cfd6f`.
+- PR #36 was open, non-draft and mergeable at
+  `3995091091fa2a1a2d66dec3ef4a965c2b2dbbe8`, with no review threads or comments.
+- GitHub Actions run `31614232189` was green at that SHA. Its logs show 47 Jest
+  suites / 505 passed / 3 todo and 221 Playwright tests passed / 3 skipped. This
+  corrects the earlier handoff's stale `119 passed` count. The run is still
+  deterministic/hosted evidence only.
+- No active `.gitl` lease or newer concurrent hotfix branch work was found. The
+  frozen Round-9 `.gitl` state describes the completed 8.8.0 release and is not
+  authority to merge or publish this candidate.
 
-### Smallest production repair (in `ghost-in-the-loop.user.js`, not the shim)
-1. Prepended `'button[aria-label="Send message"]'` to the ChatGPT reviewed
-   `send` array. The real control now resolves via `_reviewedSend()` as a single
-   reviewed actuator (`reviewed-button` → one `.click()`); the synthetic-Enter
-   fallback is not reached. Exact-node identity, uniqueness (fail-closed on
-   ambiguity), disabled/`aria-disabled` rejection, `aria-haspopup`/`aria-expanded`
-   structural veto and `SEND_VETO` are all preserved. At-most-once/single-dispatch
-   is unchanged. No actuator escalation chain was restored.
-2. `mountPanel()` installs one panel-scoped, capture-phase guard cancelling only
-   the browser default action on `#gitl button` clicks (host-form submit / anchor
-   nav → the reported jump-to-top). It does **not** `stopPropagation`, so Ghost's
-   own handlers still run; duck-typed (`el.closest`) so it is safe where the
-   userscript sandbox does not expose `Element` (a real bug the test suite
-   caught). This supersedes the shim's global default-action guard.
+### Live read-only evidence and falsified assumption
 
-The diagnostic shim `diagnostics/gitl-chatgpt-8.8-hotfix.user.js` is now
-**superseded** by the production repair and can be retired once the production
-fix is field-confirmed.
+A cloud Chrome carrier was available, but it was signed out. On the current
+public `chatgpt.com` composer, a non-sensitive unsent probe revealed exactly one
+visible enabled Send node with these facts:
 
-### Regression coverage added
-`tests/chatgpt-send-selector.test.js` — source contract (identity present and
-ordered before the generic `form button[type="submit"]`), live-DOM
-`_reviewedSend()` resolution returning the exact button, and fail-closed cases
-(ambiguous duplicates, disabled, `aria-haspopup` decoy), plus the panel-guard
-contract (prevents default, never stops propagation).
+- tag: `button`;
+- id: `composer-submit-button`;
+- `aria-label="Send prompt"`;
+- `data-testid="send-button"`;
+- no explicit `type` attribute;
+- inside the composer `form`;
+- absent while the composer was empty and present after typing.
 
-### Deterministic verification (this repair, on `hotfix/8.8-chatgpt-live-send`)
-- `npm run check:generated` → generated extension current (parity).
-- `node -c ghost-in-the-loop.user.js` → OK.
-- `npx jest` → 47 suites, 505 passed, 3 todo.
-- `npm run cert:base` → exit 0.
-- `npm run identity:oracle` → PASS (exact-head), record regenerated for 8.8.1
-  with `publishReady:false`, `publicationState:candidate-not-published`.
-- `npm run package:oracle` → staged five immutable payload files + deterministic
-  metadata.
-- `npm run test:e2e` → 119 passed / 3 skipped across Chromium, Firefox,
-  chromium-mobile (incl. `send-evidence` production-seam and full UI smoke).
+The probe text was cleared and Send was not actuated. This observation falsifies
+the statement that current ChatGPT generally uses `aria-label="Send message"`:
+the observed public layout uses two identities already present in 8.8.0. It
+does **not** rule out an authenticated, mobile, experiment or account-specific
+`Send message` variant. Because the reporter's authenticated failing layout was
+not captured, the field root cause remains **UNKNOWN**.
 
-This is **deterministic/hosted evidence only**. Per the release gate below, it is
-**not** a live-ChatGPT certification: no authenticated current-host canary was
-run in this environment. 8.8.1 must not be called live-certified until the
-canary in the "Required new release gate" section succeeds on the actual host.
+### Corrections to the candidate repair
+
+1. The `button[aria-label="Send message"]` selector remains as a bounded
+   compatibility addition, not a proven live-root-cause fix. It does not widen
+   the actuator beyond a reviewed exact semantic identity.
+2. `_reviewedSend()` now builds a deduplicated union of all safe matches across
+   the reviewed selector set and grants click authority only when that union has
+   exactly one DOM node. The previous per-selector loop could see two
+   `Send message` controls, skip that ambiguous selector, then return one control
+   because a later `data-testid` selector happened to match only it. A new
+   regression first reproduced that fail-open behavior.
+3. The candidate's panel-wide click `preventDefault()` guard was removed. The
+   production panel is appended directly to `document.body`, not a ChatGPT form,
+   and its buttons are not nested in anchors, so that guard did not demonstrate
+   the reported page-jump cause. Instead every rendered Ghost button is
+   explicitly normalized to `type="button"`, preserving normal pointer and
+   keyboard activation while remaining safe if the panel is ever reparented.
+4. The diagnostic shim remains a temporary probe and is not the production
+   architecture. Its passing tests do not certify either field symptom.
+
+### Regression coverage
+
+- `tests/chatgpt-send-selector.test.js`: `Send message` compatibility, the
+  observed public `Send prompt`/`send-button` shape, same-node selector alias
+  deduplication, cross-selector ambiguity rejection, hidden/disabled/
+  `aria-disabled`/menu/disclosure decoys, and fresh resolution after node
+  replacement.
+- `tests/sendtransaction.test.js`: source contract for union-wide exact-one
+  dispatch authority while retaining the single selected actuator transaction.
+- `tests/e2e/chatgpt-live-regression.spec.js`: real-browser fixture asserting the
+  observed public host node is unchanged, a visible alternate Send fails closed,
+  Adaptive and committee controls mutate intended Ghost state, every Ghost
+  button is `type="button"`, and no host submit, Send click, URL/hash mutation or
+  scroll movement occurs.
+
+### Attached review calibration
+
+The review correctly identified the missing compatibility identity and several
+legitimate follow-ups, but its primary conclusion exceeded its evidence. Its
+`pressEnter()` double-dispatch change is moot for this path because `engineSend`
+does not call `pressEnter()`. Its proposed sequential `requestSubmit` / Enter /
+click recovery, learned actuator fingerprints and self-healed Send authority
+were rejected because they can duplicate a delayed successful send or invent
+authority. GhostBus URL disclosure, Claude label casing, taught-selector
+uniqueness, FUZZY_CHOICE and a possibly sticky network-open counter remain
+separate follow-up candidates; none was bundled into this narrow hotfix.
+
+### Verification boundary
+
+Local runtime: Node `24.14.0`, npm `11.9.0` (CI retains the required Node 20
+parity). Completed commands on the working tree:
+
+- `npx jest tests/chatgpt-send-selector.test.js tests/sendtransaction.test.js tests/sendsafety.test.js tests/sendlayered.test.js --runInBand` → 4 suites / 61 passed.
+- `npx jest --runInBand` → 47 suites / 513 passed / 3 todo.
+- `npm run check:generated` and `npm run lint` → pass.
+- `npm run cert:base` → pass.
+- `npm run identity:oracle` → pass (`exact-head` before the new commit,
+  `publishReady:false`).
+- `npm run package:oracle` and `npm run package:check` → pass;
+  `SHA256SUMS` hash
+  `aeadf0b41bbedb63ee1ca431044b3dabe446f9881b1bd2f4a92a64339a5bb63d`.
+
+`npx playwright test tests/e2e/chatgpt-live-regression.spec.js` was attempted,
+but this worker had no installed browser binary. A second attempt with
+`PLAYWRIGHT_BROWSERS_PATH=/tmp/gitl-playwright npx playwright install chromium firefox`
+reached the download endpoint but received empty/truncated archives. Repository
+CI is therefore the browser execution oracle for the new fixture. Exact final
+SHA and CI run/job IDs must be appended after the candidate is pushed.
+
+This remains **not live-certified**. One concrete blocker-clearing action remains:
+run the authenticated canary in "Required new release gate" on the reporter's
+failing layout, capture only the composer/Send/control facts listed above, and
+approve release only if exactly one outbound turn and one continuation appear
+without a scroll jump.

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -1,0 +1,183 @@
+# ChatGPT 8.8 Live Regression — Durable Handoff
+
+Date: 2026-08-12
+Repository: `MShneur/ghost-in-the-loop`
+Stable base inspected: `main@3fa1ad3ec6bef342260864f28693331b4f3cfd6f`
+Working branch: `hotfix/8.8-chatgpt-live-send`
+Draft PR: #36
+
+## User-reported field failure
+
+After updating to Ghost in the Loop 8.8.0 on ChatGPT:
+
+1. Ghost-owned controls such as Adaptive / committee-related controls appeared not to activate and instead the page jumped/scrolled toward the top.
+2. Starting a normal Proceed/Continue path inserted the continuation text into the ChatGPT composer but did not actually dispatch/send it.
+
+Treat this as a real field regression until live authenticated verification proves otherwise.
+
+## What the 8.8 evidence actually proved
+
+The 8.8 release process had extensive deterministic/hosted evidence: Jest, Playwright, Chromium/Firefox, mobile emulation, structural tests, Red Team, lifecycle tests, long-chat/performance work, build identity, packaging, and multiple BrowserStack/live-host investigation branches.
+
+However, the release-candidate documentation explicitly bounded the result: exact current live ChatGPT structural insertion/binding was `UNKNOWN / NOT CERTIFIED`, and no qualifying authenticated live capture had been obtained. The final Round-6 structural audit likewise accepted only bounded deterministic/hosted scope.
+
+This is the key process failure: for a userscript whose core purpose is to manipulate the real composer and dispatch real messages, current authenticated live-host actuation must be a release gate, not an optional footnote.
+
+## Current production architecture relevant to the failure
+
+Ghost 8.8.0's ChatGPT adapter includes reviewed Send selectors such as:
+
+- `button[data-testid="send-button"]`
+- `button[aria-label="Send prompt"]`
+- `button[aria-label="Send"]`
+- `form button[type="submit"]`
+- broad reviewed data-testid/class send fallbacks
+
+When no unique reviewed Send button resolves, ChatGPT is allowed a reviewed single-dispatch fallback: one synthetic Enter `keydown` on the composer. That mechanism was introduced to support mobile ChatGPT while preserving the at-most-once journal: select one mechanism before dispatch, fire it once, then observe confirmation or enter uncertainty. Do not regress to the older multi-tier escalation chain merely to obtain a pass.
+
+A current semantic label such as `aria-label="Send message"` is not explicitly covered by the main 8.8 adapter. A plausible field failure is therefore:
+
+`Ghost injects Continue -> reviewed button selector misses live Send -> synthetic Enter is dispatched -> current ChatGPT ignores/does not submit the synthetic event -> text remains in composer.`
+
+This is a high-confidence hypothesis, not a claimed authenticated-live DOM observation. The connected browser carrier available during this investigation returned HTTP 404, so exact current live ChatGPT DOM binding remains unverified.
+
+## Narrow field hotfix implemented on this branch
+
+File: `diagnostics/gitl-chatgpt-8.8-hotfix.user.js`
+
+The shim is deliberately separate from the production userscript so it can be field-tested and removed without changing `main`.
+
+### Send substitution
+
+The shim listens in capture phase for an untrusted synthetic Enter on a recognized ChatGPT composer while Ghost is mounted. Before ChatGPT receives the synthetic key event, it searches locally for a unique safe semantic Send button, including `aria-label="Send message"` and closely related reviewed Send identities.
+
+When exactly one safe semantic Send resolves:
+
+1. prevent the synthetic Enter;
+2. stop its propagation to ChatGPT;
+3. invoke exactly one click on that exact Send node.
+
+This preserves one-dispatch authority. It does not fire Enter and then click.
+
+When no unique semantic Send resolves, or multiple candidates are present, the shim does not invent authority. It leaves Ghost's existing reviewed Enter path untouched.
+
+Safety vetoes reject disabled controls, popup/menu controls, and surfaces suggesting stop/voice/mic/attach/upload/tool/model/picker/dropdown/emoji/format/cancel.
+
+### Ghost-button default-action guard
+
+The shim also cancels browser/host default actions for `#gitl button` clicks while allowing Ghost's own click handlers to execute normally. Ghost controls are transport/configuration controls, not host-form submitters or anchors. This is a narrow defensive response to the reported jump-to-top symptom.
+
+Do not treat this as proof of the scroll root cause until live reproduction exists.
+
+## Regression coverage
+
+File: `tests/chatgpt-live-hotfix.test.js`
+
+The regression suite proves:
+
+1. one Ghost synthetic Enter becomes exactly one click on a unique visible `aria-label="Send message"` button and the host does not receive the synthetic key event;
+2. two plausible semantic Send buttons are ambiguous and fail closed;
+3. Ghost-owned button default action is prevented while the Ghost button's own click handler still runs.
+
+## Verification completed
+
+Draft PR #36 was opened solely to trigger ordinary repository-native CI. It is not authorization to merge or publish.
+
+CI run: `31598184515` on hotfix head `cdf3fdc26884e746c9bc7f8d8f17096db99f55cd` completed successfully.
+
+The normal CI contract includes:
+
+- Node.js 20 / `npm ci`
+- extension build and base certification
+- JavaScript syntax checks
+- Jest unit suite
+- BUILD-IDENTITY oracle
+- release-candidate packaging oracle
+- Playwright Chromium + Firefox browser safety suite
+
+The run completed green. This proves the branch is compatible with the repository's deterministic/hosted test contract. It does **not** prove the affected authenticated ChatGPT page is fixed.
+
+## Rejected repair direction
+
+Do not restore the historical button -> Enter -> `insertParagraph` -> form-submit actuator escalation chain as a first response. That architecture can create double-dispatch risk when an earlier actuator succeeds slowly. The current single-dispatch journal/uncertainty design was introduced specifically to avoid that failure class.
+
+Prefer semantic identity + exact uniqueness + one selected actuator + confirmation/uncertainty.
+
+## Recommended production repair direction
+
+The field shim is diagnostic/temporary. A production-quality repair should be made in the primary adapter/actuator code after current live DOM evidence is obtained.
+
+Preferred direction:
+
+1. Capture the exact authenticated current ChatGPT composer and Send control on the failing layout(s).
+2. Add the smallest reviewed semantic selector/identity needed (for example `aria-label="Send message"` only if actually observed).
+3. Preserve exact-node identity and safe-send vetoes.
+4. Preserve one-dispatch transaction semantics; no sequential actuator escalation after an unconfirmed dispatch.
+5. Make Ghost-owned buttons explicitly `type="button"` where appropriate and/or centrally prevent host default actions without suppressing Ghost handlers.
+6. Add a production-level Playwright fixture reproducing the exact live DOM shape and the reported control behavior.
+7. Re-run syntax, generated parity, unit, base certification, Playwright Chromium/Firefox, build identity, packaging/checksum gates, and any applicable mobile lanes.
+8. Perform an authenticated live canary before any release claim.
+
+## Required new release gate
+
+For ChatGPT support, a release must not be called live-certified/publish-ready unless a current authenticated canary proves the complete path on the actual host:
+
+`Ghost control click -> expected Ghost state mutation -> composer injection -> exact real Send activation -> outbound user message appears -> model generation begins -> one automatic continuation dispatch occurs -> no duplicate send.`
+
+If a current authenticated live canary cannot run, record ChatGPT live support as unverified and block the live-support/release claim. Deterministic fixtures, BrowserStack, emulation, and CI remain supporting evidence, not substitutes.
+
+## Tools and environments relevant to continuation
+
+Use only tools that are actually available in the current environment; verify before claiming use.
+
+Repository-native / known project capabilities:
+
+- Git repository and GitHub PR/Actions workflow.
+- Node.js 20 in CI.
+- npm scripts in `package.json` for build, generated parity, certification, lint, Jest, Playwright, BUILD-IDENTITY, packaging, and candidate checks.
+- Jest + jsdom unit testing.
+- Playwright browser testing with Chromium and Firefox in ordinary CI.
+- Existing mobile, lifecycle, long-chat, send-safety, structural, repair/resume, accessibility and performance fixtures under `tests/` and `tests/e2e/`.
+- Diagnostic userscripts under `diagnostics/`, including the current field hotfix and existing canary machinery.
+- Tampermonkey/userscript field testing on real supported sites when a human or authenticated browser carrier is available.
+- Historical BrowserStack/live-host branches for Chrome/Edge/Firefox/Safari, macOS, Android, iOS/iPad and device variants. Do not assume credentials/secrets exist; use only configured repository/environment access.
+- GitHub Actions can be used as a guarded execution carrier when local execution is unavailable, subject to the repository's orchestration/evidence rules.
+
+External/live capabilities that may or may not exist for a given worker:
+
+- authenticated browser/devtools/Playwright carrier against real ChatGPT;
+- web/network research;
+- BrowserStack credentials/devices;
+- local shell/browser automation beyond the repository's ordinary CI.
+
+Probe these capabilities rather than assuming them.
+
+## Personal Forge and durable coordination
+
+The repository's `.gitl/orchestration/README.md` states that the autonomous control plane combines GitHub durable state with the canonical Personal-Forge maker and explicit user directives. Personal Forge is therefore part of project coordination/roadmap authority, but private Forge content must not be copied into this public repository.
+
+A continuation worker that has Personal Forge access should:
+
+1. locate/read the existing Ghost coordination record / canonical maker before changing project direction;
+2. reconcile it with `.gitl/autopilot-state.json`, `.gitl/orchestration/round-plan.json`, task prompts, evidence contracts, user directives and current GitHub branch/CI state;
+3. keep private Forge material private;
+4. write durable non-sensitive implementation/test evidence to GitHub so work does not exist only in chat or Forge.
+
+If Personal Forge is unavailable in the worker environment, record that limitation and continue from the durable GitHub state without inventing Forge contents.
+
+## Orchestration and safety constraints
+
+Read `.gitl/orchestration/README.md` and linked state/evidence files before broad project work. Important constraints include:
+
+- sweep/reproduce before patching;
+- durable evidence over chat summaries;
+- check shared lease/branch activity before coordinated writes when operating under the autonomous-round protocol;
+- never merge, enable auto-merge, tag, publish, create a GitHub Release, or change the stable public userscript channel without explicit authority;
+- never weaken Send, CHOICE, route, lease, uncertainty, exact-identity or structural-demotion safeguards to make tests pass;
+- never claim live-site behavior, hardware, sources or tests that were not actually observed.
+
+## Current decision boundary
+
+The branch and PR are ready for independent review and deeper repair work, but they are **not production-certified for live ChatGPT** until an authenticated current-host reproduction/canary succeeds.
+
+The most valuable next step is independent reproduction and repair of the production adapter with a real current ChatGPT composer, followed by a field canary. If that carrier is unavailable, improve deterministic coverage without converting it into a live-certification claim.

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -294,8 +294,29 @@ parity). Completed commands on the working tree:
 but this worker had no installed browser binary. A second attempt with
 `PLAYWRIGHT_BROWSERS_PATH=/tmp/gitl-playwright npx playwright install chromium firefox`
 reached the download endpoint but received empty/truncated archives. Repository
-CI is therefore the browser execution oracle for the new fixture. Exact final
-SHA and CI run/job IDs must be appended after the candidate is pushed.
+CI was therefore used as the browser execution oracle.
+
+Final code-bearing head `b7c694e38306f063bfc8d2109127b78359bfa2ac`
+completed GitHub Actions run `31619121019` successfully:
+
+- Unit/base job `94189202923`: Node `20.20.2`, npm `10.8.2`; 47 suites /
+  513 passed / 3 todo; generated parity, syntax, base certification,
+  BUILD-IDENTITY (`head-moved-payload-identical`, `publishReady:false`) and
+  packaging passed.
+- Playwright job `94189203012`: 237 cases across Chromium, Firefox and selected
+  mobile lanes; 227 passed / 10 skipped. All six new ChatGPT regression
+  executions passed in Chromium and Firefox.
+- Candidate `SHA256SUMS`:
+  `aeadf0b41bbedb63ee1ca431044b3dabe446f9881b1bd2f4a92a64339a5bb63d`.
+- Artifacts: release-candidate package `9150492288`; base certification
+  `9150492815`.
+
+Intermediate run `31618551192` failed the first resolver fixture because its
+mock Send was placed 4,700 px off-screen; `_visible()` correctly rejected it,
+leaving the fixed alternate as the only visible candidate. The independent
+control-state/no-scroll test passed in both engines. Commit `b7c694e` scrolls
+the intended mock Send into view before resolver assertions; no production code
+changed in that follow-up.
 
 This remains **not live-certified**. One concrete blocker-clearing action remains:
 run the authenticated canary in "Required new release gate" on the reporter's

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -4,7 +4,7 @@ Date: 2026-08-12
 Repository: `MShneur/ghost-in-the-loop`
 Stable base inspected: `main@3fa1ad3ec6bef342260864f28693331b4f3cfd6f`
 Working branch: `hotfix/8.8-chatgpt-live-send`
-Draft PR: #36
+PR: #36 (open, non-draft)
 Claude Code handoff prompt: `docs/CLAUDE_CODE_CHATGPT_8_8_LIVE_REGRESSION_PROMPT.md`
 
 ## User-reported field failure
@@ -24,7 +24,7 @@ However, the release-candidate documentation explicitly bounded the result: exac
 
 This is the key process failure: for a userscript whose core purpose is to manipulate the real composer and dispatch real messages, current authenticated live-host actuation must be a release gate, not an optional footnote.
 
-## Current production architecture relevant to the failure
+## Initial 8.8.0 production architecture and hypothesis
 
 Ghost 8.8.0's ChatGPT adapter includes reviewed Send selectors such as:
 
@@ -36,11 +36,17 @@ Ghost 8.8.0's ChatGPT adapter includes reviewed Send selectors such as:
 
 When no unique reviewed Send button resolves, ChatGPT is allowed a reviewed single-dispatch fallback: one synthetic Enter `keydown` on the composer. That mechanism was introduced to support mobile ChatGPT while preserving the at-most-once journal: select one mechanism before dispatch, fire it once, then observe confirmation or enter uncertainty. Do not regress to the older multi-tier escalation chain merely to obtain a pass.
 
-A current semantic label such as `aria-label="Send message"` is not explicitly covered by the main 8.8 adapter. A plausible field failure is therefore:
+At the initial investigation stage, a semantic label such as
+`aria-label="Send message"` was not explicitly covered by the main 8.8 adapter.
+A plausible field failure was therefore:
 
 `Ghost injects Continue -> reviewed button selector misses live Send -> synthetic Enter is dispatched -> current ChatGPT ignores/does not submit the synthetic event -> text remains in composer.`
 
-This is a high-confidence hypothesis, not a claimed authenticated-live DOM observation. The connected browser carrier available during this investigation returned HTTP 404, so exact current live ChatGPT DOM binding remains unverified.
+This was a leading hypothesis, not an authenticated-live DOM observation. The
+first connected browser carrier returned HTTP 404. The later signed-out public
+probe documented under “Independent takeover correction” did not observe this
+label and reduced confidence in the hypothesis; authenticated binding remains
+unverified.
 
 ## Narrow field hotfix implemented on this branch
 
@@ -96,7 +102,10 @@ The normal CI contract includes:
 - release-candidate packaging oracle
 - Playwright Chromium + Firefox browser safety suite
 
-The run completed green. This proves the code-bearing hotfix head is compatible with the repository's deterministic/hosted test contract. Later commits on the branch add documentation only; they do not broaden the live-certification claim.
+The run completed green. This proved that the historical shim head was
+compatible with the repository's deterministic/hosted test contract. It was
+later superseded by the production changes and newer evidence documented below;
+it never broadened the live-certification claim.
 
 ## Rejected repair direction
 
@@ -332,3 +341,84 @@ run the authenticated canary in "Required new release gate" on the reporter's
 failing layout, capture only the composer/Send/control facts listed above, and
 approve release only if exactly one outbound turn and one continuation appear
 without a scroll jump.
+
+---
+
+## Final release-hardening pass (2026-08-12)
+
+The final pre-field-test sweep rechecked live GitHub rather than relying on the
+earlier report. `main` remained
+`3fa1ad3ec6bef342260864f28693331b4f3cfd6f`; PR #36 was the only open pull
+request, remained non-draft and mergeable, and had no reviews or review threads.
+No newer concurrent pull-request or `main`-branch work was found.
+
+### Additional exact-one failure reproduced and repaired
+
+The previous global-union repair still returned `TeachStore.matchEl('send')`
+before examining the built-in reviewed selector union. A human-taught selector
+could therefore drift from one eligible node to two, return its first match,
+and bypass ambiguity rejection even when only one of those nodes also matched a
+built-in reviewed alias.
+
+A regression was added first and failed as expected:
+
+- command: `npx jest tests/chatgpt-send-selector.test.js --runInBand`;
+- observed result: 1 failed / 17 passed;
+- failure: `_reviewedSend()` returned the first `button.taught-send` instead of
+  `null` when that selector matched two visible veto-safe controls.
+
+Production `_reviewedSend()` now collects the human-taught selector and every
+built-in reviewed selector into the same `Set`, deduplicates aliases for the
+same node, and returns only when the complete authority union contains exactly
+one eligible DOM node. A taught actuator still works on an unreviewed host when
+it is unique. No new actuator, retry, form submission, Enter sequence, or
+authority-widening path was added.
+
+### Final deterministic and hosted verification
+
+Code-bearing head:
+`275919c0e78312e2ed9bfd03f0422faddd90c2b0`.
+
+Local Node `24.14.0` / npm `11.9.0` results:
+
+- focused repaired suites: 3 suites / 39 passed;
+- full `npm test -- --runInBand`: 47 suites / 514 passed / 3 todo;
+- `npm run lint`, `npm run check:generated`, `npm run cert:base`,
+  `npm run identity:oracle`, `npm run package:oracle`, and
+  `npm run package:check`: pass;
+- package `SHA256SUMS`:
+  `8469497e85bd2a1f1b78aac96a2f8c7cfe8e4d9b31f952492e944d551ecf7284`;
+- `npm audit --omit=dev --json`: 0 vulnerabilities. Full development audit
+  still reports the previously documented two high-severity transitive nodes,
+  `brace-expansion` and `js-yaml`; no shipped-payload path was established.
+
+Local Playwright execution was attempted for the ChatGPT and Teach fixtures.
+The worker still lacked a browser executable, and a permitted Chromium install
+retried five times but received a `0 MiB`/truncated archive. This is an
+environment limitation, not a test assertion failure.
+
+GitHub Actions run
+[`31624115333`](https://github.com/MShneur/ghost-in-the-loop/actions/runs/31624115333)
+completed successfully on the code-bearing head:
+
+- Unit/base job `94206004939`: Node `20.20.2`, npm `10.8.2`; 47 suites /
+  514 passed / 3 todo; generated parity, syntax, base certification,
+  BUILD-IDENTITY (`head-moved-payload-identical`, `publishReady:false`) and
+  packaging passed.
+- Playwright job `94206004903`: 239 cases across Chromium, Firefox and selected
+  mobile lanes; 229 passed / 10 skipped. The new taught-selector drift fixture
+  passed in both Chromium and Firefox, as did all six ChatGPT Send/control
+  regression executions.
+- Artifacts: release-candidate package `9152416065`, base certification
+  `9152416779`, and E2E results `9152546359`.
+- Candidate `SHA256SUMS` matched the local oracle:
+  `8469497e85bd2a1f1b78aac96a2f8c7cfe8e4d9b31f952492e944d551ecf7284`.
+
+Stable `@updateURL` / `@downloadURL` values remain unchanged and point to
+`main`. No merge, auto-merge, tag, GitHub Release, stable-channel update, or
+publication action was performed.
+
+The evidence boundary is unchanged: the candidate is safer and more completely
+tested, but the authenticated field root cause and live repair status remain
+**UNKNOWN** until the reporter's failing layout completes the one-dispatch/no-
+scroll-jump canary.

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -182,3 +182,73 @@ Read `.gitl/orchestration/README.md` and linked state/evidence files before broa
 The branch and PR are ready for independent review and deeper repair work, but they are **not production-certified for live ChatGPT** until an authenticated current-host reproduction/canary succeeds.
 
 The most valuable next step is independent reproduction and repair of the production adapter with a real current ChatGPT composer, followed by a field canary. If that carrier is unavailable, improve deterministic coverage without converting it into a live-certification claim.
+
+---
+
+## Independent takeover — production repair (8.8.1)
+
+A second worker independently reviewed the branch, PR #36, current `main@8.8.0`,
+the diagnostic shim, and the multi-agent field reviews, then reconciled against
+the Personal-Forge Ghost coordination record (post-release takeover handoff:
+8.8 on stable channel; preserve exact reviewed Send identity, at-most-once
+dispatch, CHOICE/route/lease/uncertainty; native takeover is future work).
+
+### Reproduced deterministically
+- `main@8.8.0` ChatGPT adapter `send` list does **not** contain
+  `button[aria-label="Send message"]`; `pressEnter()` has **no callers** in the
+  send path (the single-dispatch `reviewed-enter` strategy fires one inline
+  `keydown`, so the reports' `pressEnter` concern is moot for the transaction).
+- The failure chain is therefore: inject Continue → `_reviewedSend()` returns
+  null (no reviewed identity matches the live control) → `engineSend` selects
+  the reviewed synthetic-Enter fallback → current ChatGPT ignores the synthetic
+  key → text remains in the composer. This matches the field report exactly.
+
+### Evidence for `aria-label="Send message"` (no authenticated live capture available)
+Converging, non-authenticated: the repo's own test fixture, the Gemini adapter's
+existing use of the identity, multiple independent multi-model reviews, and an
+external maintained ChatGPT userscript all cite `aria-label="Send message"` as
+the current live composer Send control. The connected browser carrier was
+unavailable, so exact authenticated-live DOM remains **UNVERIFIED**.
+
+### Smallest production repair (in `ghost-in-the-loop.user.js`, not the shim)
+1. Prepended `'button[aria-label="Send message"]'` to the ChatGPT reviewed
+   `send` array. The real control now resolves via `_reviewedSend()` as a single
+   reviewed actuator (`reviewed-button` → one `.click()`); the synthetic-Enter
+   fallback is not reached. Exact-node identity, uniqueness (fail-closed on
+   ambiguity), disabled/`aria-disabled` rejection, `aria-haspopup`/`aria-expanded`
+   structural veto and `SEND_VETO` are all preserved. At-most-once/single-dispatch
+   is unchanged. No actuator escalation chain was restored.
+2. `mountPanel()` installs one panel-scoped, capture-phase guard cancelling only
+   the browser default action on `#gitl button` clicks (host-form submit / anchor
+   nav → the reported jump-to-top). It does **not** `stopPropagation`, so Ghost's
+   own handlers still run; duck-typed (`el.closest`) so it is safe where the
+   userscript sandbox does not expose `Element` (a real bug the test suite
+   caught). This supersedes the shim's global default-action guard.
+
+The diagnostic shim `diagnostics/gitl-chatgpt-8.8-hotfix.user.js` is now
+**superseded** by the production repair and can be retired once the production
+fix is field-confirmed.
+
+### Regression coverage added
+`tests/chatgpt-send-selector.test.js` — source contract (identity present and
+ordered before the generic `form button[type="submit"]`), live-DOM
+`_reviewedSend()` resolution returning the exact button, and fail-closed cases
+(ambiguous duplicates, disabled, `aria-haspopup` decoy), plus the panel-guard
+contract (prevents default, never stops propagation).
+
+### Deterministic verification (this repair, on `hotfix/8.8-chatgpt-live-send`)
+- `npm run check:generated` → generated extension current (parity).
+- `node -c ghost-in-the-loop.user.js` → OK.
+- `npx jest` → 47 suites, 505 passed, 3 todo.
+- `npm run cert:base` → exit 0.
+- `npm run identity:oracle` → PASS (exact-head), record regenerated for 8.8.1
+  with `publishReady:false`, `publicationState:candidate-not-published`.
+- `npm run package:oracle` → staged five immutable payload files + deterministic
+  metadata.
+- `npm run test:e2e` → 119 passed / 3 skipped across Chromium, Firefox,
+  chromium-mobile (incl. `send-evidence` production-seam and full UI smoke).
+
+This is **deterministic/hosted evidence only**. Per the release gate below, it is
+**not** a live-ChatGPT certification: no authenticated current-host canary was
+run in this environment. 8.8.1 must not be called live-certified until the
+canary in the "Required new release gate" section succeeds on the actual host.

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -5,6 +5,7 @@ Repository: `MShneur/ghost-in-the-loop`
 Stable base inspected: `main@3fa1ad3ec6bef342260864f28693331b4f3cfd6f`
 Working branch: `hotfix/8.8-chatgpt-live-send`
 Draft PR: #36
+Claude Code handoff prompt: `docs/CLAUDE_CODE_CHATGPT_8_8_LIVE_REGRESSION_PROMPT.md`
 
 ## User-reported field failure
 
@@ -83,7 +84,7 @@ The regression suite proves:
 
 Draft PR #36 was opened solely to trigger ordinary repository-native CI. It is not authorization to merge or publish.
 
-CI run: `31598184515` on hotfix head `cdf3fdc26884e746c9bc7f8d8f17096db99f55cd` completed successfully.
+CI run: `31598184515` on code-bearing hotfix head `cdf3fdc26884e746c9bc7f8d8f17096db99f55cd` completed successfully.
 
 The normal CI contract includes:
 
@@ -95,7 +96,7 @@ The normal CI contract includes:
 - release-candidate packaging oracle
 - Playwright Chromium + Firefox browser safety suite
 
-The run completed green. This proves the branch is compatible with the repository's deterministic/hosted test contract. It does **not** prove the affected authenticated ChatGPT page is fixed.
+The run completed green. This proves the code-bearing hotfix head is compatible with the repository's deterministic/hosted test contract. Later commits on the branch add documentation only; they do not broaden the live-certification claim.
 
 ## Rejected repair direction
 

--- a/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
+++ b/docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md
@@ -234,11 +234,14 @@ not captured, the field root cause remains **UNKNOWN**.
    compatibility addition, not a proven live-root-cause fix. It does not widen
    the actuator beyond a reviewed exact semantic identity.
 2. `_reviewedSend()` now builds a deduplicated union of all safe matches across
-   the reviewed selector set and grants click authority only when that union has
-   exactly one DOM node. The previous per-selector loop could see two
-   `Send message` controls, skip that ambiguous selector, then return one control
-   because a later `data-testid` selector happened to match only it. A new
-   regression first reproduced that fail-open behavior.
+   both the reviewed selector set and any human-taught Send selector, and grants
+   click authority only when that complete authority union has exactly one DOM
+   node. The previous per-selector loop could see two `Send message` controls,
+   skip that ambiguous selector, then return one control because a later
+   `data-testid` selector happened to match only it. A subsequent hardening pass
+   also reproduced a taught selector matching two live controls while a built-in
+   alias matched only one; the old taught-first path returned that first node.
+   Both ambiguity bypasses now fail closed.
 3. The candidate's panel-wide click `preventDefault()` guard was removed. The
    production panel is appended directly to `document.body`, not a ChatGPT form,
    and its buttons are not nested in anchors, so that guard did not demonstrate
@@ -252,11 +255,14 @@ not captured, the field root cause remains **UNKNOWN**.
 
 - `tests/chatgpt-send-selector.test.js`: `Send message` compatibility, the
   observed public `Send prompt`/`send-button` shape, same-node selector alias
-  deduplication, cross-selector ambiguity rejection, hidden/disabled/
-  `aria-disabled`/menu/disclosure decoys, and fresh resolution after node
-  replacement.
+  deduplication, cross-selector and taught-selector ambiguity rejection,
+  hidden/disabled/`aria-disabled`/menu/disclosure decoys, and fresh resolution
+  after node replacement.
 - `tests/sendtransaction.test.js`: source contract for union-wide exact-one
   dispatch authority while retaining the single selected actuator transaction.
+- `tests/e2e/teach.spec.js`: real-browser proof that a uniquely taught actuator
+  remains available on an unreviewed host, but a later two-node selector drift
+  returns no actuator.
 - `tests/e2e/chatgpt-live-regression.spec.js`: real-browser fixture asserting the
   observed public host node is unchanged, a visible alternate Send fails closed,
   Adaptive and committee controls mutate intended Ghost state, every Ghost
@@ -265,15 +271,18 @@ not captured, the field root cause remains **UNKNOWN**.
 
 ### Attached review calibration
 
-The review correctly identified the missing compatibility identity and several
-legitimate follow-ups, but its primary conclusion exceeded its evidence. Its
+The review correctly identified the missing compatibility identity, the
+taught-selector uniqueness weakness, and several legitimate follow-ups, but its
+primary conclusion exceeded its evidence. Its
 `pressEnter()` double-dispatch change is moot for this path because `engineSend`
 does not call `pressEnter()`. Its proposed sequential `requestSubmit` / Enter /
 click recovery, learned actuator fingerprints and self-healed Send authority
 were rejected because they can duplicate a delayed successful send or invent
-authority. GhostBus URL disclosure, Claude label casing, taught-selector
-uniqueness, FUZZY_CHOICE and a possibly sticky network-open counter remain
-separate follow-up candidates; none was bundled into this narrow hotfix.
+authority. Taught-selector uniqueness is now included because it directly
+enforces the existing exact-one invariant without widening authority. GhostBus
+URL disclosure, Claude label casing, FUZZY_CHOICE and a possibly sticky
+network-open counter remain separate follow-up candidates; none was bundled
+into this narrow hotfix.
 
 ### Verification boundary
 

--- a/docs/CLAUDE_CODE_CHATGPT_8_8_LIVE_REGRESSION_PROMPT.md
+++ b/docs/CLAUDE_CODE_CHATGPT_8_8_LIVE_REGRESSION_PROMPT.md
@@ -1,0 +1,175 @@
+# Claude Code Prompt — Ghost in the Loop 8.8 ChatGPT Live Regression
+
+You are taking over an active Ghost in the Loop field-regression investigation.
+
+Repository: `MShneur/ghost-in-the-loop`
+Working branch: `hotfix/8.8-chatgpt-live-send`
+Draft PR: `#36`
+Stable base when the investigation began: `main@3fa1ad3ec6bef342260864f28693331b4f3cfd6f`
+
+Your goal is not to defend the existing hotfix. Independently reproduce, critique, improve, or replace it with the smallest evidence-backed production repair.
+
+## Start by reading durable state
+
+Before changing code, read at minimum:
+
+- `docs/CHATGPT_8_8_LIVE_REGRESSION_HANDOFF.md`
+- `diagnostics/gitl-chatgpt-8.8-hotfix.user.js`
+- `tests/chatgpt-live-hotfix.test.js`
+- `ghost-in-the-loop.user.js`
+- `package.json`
+- `playwright.config.js`
+- `.github/workflows/test.yml`
+- `.gitl/orchestration/README.md`
+- `.gitl/autopilot-state.json`
+- `.gitl/orchestration/round-plan.json`
+- `.gitl/orchestration/task-prompts.md`
+- `.gitl/orchestration/evidence-contract.md`
+- applicable `.gitl/user-directives/`, `.gitl/deferred-questions.md`, and relevant Round-6/7/8 evidence
+- `docs/RELEASE-CANDIDATE-8.8.md`
+
+Also inspect PR #36, its current diff, current CI, recent related commits/issues, and any newer branch movement before writing.
+
+## Personal Forge
+
+Ghost's orchestration documentation says the durable control plane is coordinated with a canonical Personal-Forge maker/coordination record. If your environment has Personal Forge access, locate and read the existing Ghost coordination record before changing project direction, then reconcile it with GitHub durable state.
+
+Do **not** copy private Personal Forge content into this public repository, logs, third-party services, or chat. Summarize only non-sensitive decisions/evidence that must become durable GitHub state.
+
+If Personal Forge is not accessible from Claude Code, explicitly record `Personal Forge unavailable in this environment` and continue from authoritative GitHub state. Do not invent its contents and do not block narrow reversible debugging solely because Forge is unavailable.
+
+## Field failure to reproduce
+
+User reports after updating to 8.8.0 on real ChatGPT:
+
+1. Pressing Ghost controls such as Adaptive/committee-related controls does not appear to activate them and instead the page jumps/scrolls toward the beginning/top.
+2. Starting a normal Proceed/Continue path inserts the continuation text into the ChatGPT composer but does not actually send it.
+
+Treat those as field facts. The exact DOM/event cause is still open.
+
+## Important evidence boundary
+
+8.8 had extensive deterministic/hosted testing, but its own release evidence explicitly left exact current live ChatGPT structural insertion/binding `UNKNOWN / NOT CERTIFIED`. Do not cite fixture/CI success as proof that real ChatGPT works.
+
+A previous connected authenticated browser carrier used by ChatGPT in this investigation returned HTTP 404, so no fresh authenticated live DOM capture was obtained there.
+
+## Current hypothesis and temporary hotfix
+
+The production ChatGPT adapter has reviewed Send selectors including `Send`, `Send prompt`, data-testid send/submit, and `form button[type=submit]`. When no unique reviewed button resolves, it may choose one reviewed synthetic Enter dispatch.
+
+A plausible current-host drift is a real Send button such as `button[type=button][aria-label="Send message"]`: Ghost injects text, misses the real button, fires synthetic Enter, and ChatGPT no longer submits that synthetic event.
+
+The temporary diagnostic userscript on this branch intercepts Ghost's untrusted Enter and, only when exactly one safe semantic Send resolves, substitutes exactly one button click. It also prevents default browser/host action on `#gitl button` clicks while allowing Ghost handlers to run.
+
+Do not assume this hypothesis is correct. Try to falsify it.
+
+## Non-negotiable Send safety
+
+Preserve the current at-most-once/single-dispatch contract.
+
+Do **not** casually restore a sequential actuator escalation chain such as:
+
+`button click -> Enter -> beforeinput/insertParagraph -> requestSubmit`
+
+That can create duplicate sends if an earlier mechanism succeeds slowly. Preferred architecture is:
+
+`resolve exact authority -> choose one actuator before transaction -> fire once -> observe confirmation -> otherwise uncertainty/manual recovery`.
+
+Fail closed on ambiguous Send identity. Never widen authority just to make a test pass.
+
+## Tools and environments to use if actually available
+
+Probe the environment first; do not claim tools you did not use.
+
+Expected repository/local capabilities may include:
+
+- normal shell, git, grep/ripgrep, diff, Node/npm;
+- Node.js 20 parity with CI;
+- Jest + jsdom;
+- Playwright;
+- Chromium and Firefox;
+- repository npm scripts for build, generated parity, certification, lint, unit, E2E, BUILD-IDENTITY, packaging and candidate checks;
+- GitHub CLI/API or connected GitHub access;
+- GitHub Actions as an ordinary CI oracle and, when authorized by project rules, a guarded temporary execution carrier;
+- existing tests under `tests/` and `tests/e2e/` covering send safety, structural behavior, mobile, lifecycle, long chat, repair/resume, accessibility and performance;
+- diagnostics userscripts/canaries under `diagnostics/`;
+- Tampermonkey/userscript installation for human field testing.
+
+Potential live/external capabilities that may exist but must be verified:
+
+- authenticated browser/devtools/Playwright against real `chatgpt.com`;
+- Chrome DevTools Protocol or another browser automation carrier;
+- BrowserStack credentials and real/hosted devices/browsers;
+- web/network research;
+- macOS/Safari, Android, iOS/iPad, Firefox/Gecko environments represented by historical BrowserStack/live-host branches.
+
+Do not request or expose secrets. Use existing configured environment variables/secrets only. Do not send private Personal Forge material to external services.
+
+## Preferred investigation sequence
+
+1. **Sweep before patching.** Check repo/branch/PR/CI/current head and adjacent send/control code.
+2. **Reproduce current branch behavior deterministically.** Run focused existing tests and the new hotfix regression test.
+3. **Attempt authenticated live reproduction if a carrier exists.** Capture exact composer and Send DOM, attributes, containing form/composer structure, relevant event behavior, and what changes before/after a genuine user click. Do not capture unrelated private conversation content; use a disposable/new chat and minimal test text.
+4. Determine separately why Ghost UI controls trigger a page jump. Inspect default button type, event default handling, focus restoration, rerender behavior, scroll anchoring, host form ancestry, and any anchor/hash interaction. Do not collapse this into the Send bug without evidence.
+5. Falsify the current semantic-Send hypothesis. Check whether `aria-label="Send message"` is actually present and unique, whether the real Send is a button, whether it is disabled/aria-disabled, whether `.click()` is accepted, and whether ChatGPT requires a different trusted interaction path.
+6. If live evidence supports a production change, patch the **primary adapter/actuator code**, not only the diagnostic shim. Keep the change minimal and reviewed-site-specific.
+7. Add production-level regression fixtures matching the captured live DOM semantics. Include ambiguity/decoy/disabled controls and exact one-dispatch assertions.
+8. Make Ghost-owned non-submit controls explicitly `type="button"` where appropriate and/or centralize default-action prevention if evidence supports the scroll fix. Preserve accessibility and keyboard activation.
+9. Check adjacent supported ChatGPT layouts: desktop, narrow/mobile, new/old composer variants if available. Do not infer other platforms from ChatGPT.
+10. Run the strongest available verification set: syntax, generated parity, unit, focused tests, base certification, Playwright Chromium/Firefox, send-safety/red-team, build identity, packaging/checksum, and applicable mobile/live lanes.
+11. If authenticated live access exists, run a final canary proving the entire path: `Ghost control click -> Ghost state mutation -> injection -> exact real Send -> outbound message appears -> generation begins -> one automatic continuation -> no duplicate send`.
+12. Write durable evidence to GitHub. Update the handoff/PR with exact commands, run/job IDs, tested SHA, observed limitations, rejected hypotheses, and remaining uncertainty.
+
+## Testing discipline
+
+A test must detect the reported failure, not merely prove our code executed.
+
+Required assertions should cover, where applicable:
+
+- exact Send-node identity;
+- one actuator invocation per transaction;
+- no hidden/secondary/decoy control chosen;
+- ambiguous Send fails closed;
+- composer text clears / outbound turn appears / generation evidence begins as appropriate;
+- no duplicate turn after delayed confirmation;
+- Ghost control click changes intended Ghost state;
+- Ghost control click does not navigate, change hash, submit host forms, or jump scroll unexpectedly;
+- handlers remain keyboard-accessible;
+- route/lease/CHOICE/uncertainty safeguards remain intact.
+
+Use mutation/adversarial tests where they improve confidence. Do not weaken an existing oracle or threshold to obtain green CI.
+
+## Release-process recommendation to preserve
+
+The project should add an explicit live-host release gate for any site claimed as currently supported. For ChatGPT, deterministic fixtures, Playwright, BrowserStack and CI are supporting evidence, not substitutes for a current authenticated canary.
+
+If the canary cannot run, the release state must say live ChatGPT is unverified and must not claim live certification/publish-ready support for that host.
+
+## Git / publication boundaries
+
+- Work on an isolated branch/PR.
+- Do not modify `main` directly.
+- Do not merge.
+- Do not enable auto-merge.
+- Do not tag or publish.
+- Do not create a GitHub Release.
+- Do not change stable userscript update/download URLs.
+- Do not expose secrets or private Personal Forge content.
+
+## Expected deliverable
+
+Do the work, do not merely recommend it when it is safely executable.
+
+Return and commit a durable report containing:
+
+- reproduced failure(s) and exact environment;
+- root cause with evidence, or `UNKNOWN` if not proven;
+- alternatives tested/rejected;
+- exact code changes;
+- tests added/changed;
+- exact commands and CI/live results tied to SHA;
+- adjacent risks;
+- what remains uncertified;
+- one recommended next action if a genuine blocker remains.
+
+If you find that the current hotfix is wrong, replace it rather than defending it. If you cannot obtain live authenticated evidence, improve the deterministic reproduction and production patch only to the level the evidence supports, and label live behavior `UNKNOWN`.

--- a/extension/content.js
+++ b/extension/content.js
@@ -999,6 +999,12 @@ function _reviewedSend() {
   const taught = TeachStore.matchEl('send');
   if (taught && !taught.disabled && taught.getAttribute('aria-disabled') !== 'true') return taught;
   if (!PLAT?.reviewed) return null;
+  // Resolve the full reviewed selector set before granting authority. A page can
+  // expose two plausible controls where only one also matches a later, more
+  // specific selector. Returning that later singleton would bypass the earlier
+  // ambiguity and silently guess. Deduplicate the same DOM node across selector
+  // aliases, but fail closed if the union contains more than one safe actuator.
+  const candidates = new Set();
   for (const sel of PLAT.send || []) {
     let matches = [];
     try {
@@ -1011,9 +1017,10 @@ function _reviewedSend() {
     } catch(_) {
       matches = [];
     }
-    if (matches.length === 1) return matches[0];
+    for (const match of matches) candidates.add(match);
+    if (candidates.size > 1) return null;
   }
-  return null;
+  return candidates.size === 1 ? [...candidates][0] : null;
 }
 
 /* ── Answer selection (v8.5.3 item 1) ────────────────────────
@@ -5221,18 +5228,6 @@ function mountPanel() {
   // the natural resting state, so nothing downstream can depend on it.
   try { panel.classList.add('g-enter'); setTimeout(() => panel.classList.remove('g-enter'), 400); } catch(_) {}
   panel.addEventListener('click', _explainIntercept, true); // capture: explain mode swallows clicks before handlers
-  // Ghost controls are transport/configuration controls, never host-form
-  // submitters or anchors. Cancel only the browser's DEFAULT action on any Ghost
-  // button click (host-form submit / navigation → the reported jump-to-top on
-  // ChatGPT). We do NOT stopPropagation, so Ghost's own click handlers still run,
-  // and this covers every button across re-renders since it's delegated on the
-  // panel root. Buttons carry no meaningful default action, so this is inert
-  // except when a host form/anchor would otherwise hijack the click.
-  panel.addEventListener('click', (e) => {
-    const t = e.target;
-    const btn = t && t.closest ? t.closest('#gitl button') : null;
-    if (btn && !btn.closest('a[href]')) e.preventDefault();
-  }, true);
 }
 
 /* Escape untrusted text before interpolating into innerHTML templates.
@@ -5853,6 +5848,11 @@ function render() {
         ${tab==='settings'?renderSettingsTab():''}
       </div>
     </div>`);
+  // Every Ghost button is a panel control, never a submitter. Declare that
+  // native semantic after each template render instead of cancelling every
+  // click's default action. This preserves normal pointer/keyboard activation
+  // and remains safe if a host later reparents the panel near a form.
+  panel.querySelectorAll('button:not([type])').forEach(button => button.setAttribute('type', 'button'));
   bindEvents();
   applyPosition(GHOST.ui.position);
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -81,7 +81,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.8.0';
+const VER = '8.8.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop';
 
@@ -516,7 +516,7 @@ const PROFILES = {
     host: /chatgpt\.com|chat\.openai\.com/,
     label: 'ChatGPT',
     input: ['#prompt-textarea','div[contenteditable="true"][id="prompt-textarea"]','div[contenteditable="true"][data-placeholder]','textarea[data-id="root"]','textarea'],
-    send: ['button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[data-testid*="send"]','button[data-testid*="submit"]','button[class*="send"]'],
+    send: ['button[aria-label="Send message"]','button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[data-testid*="send"]','button[data-testid*="submit"]','button[class*="send"]'],
     stop: ['button[aria-label="Stop generating"]','button[data-testid="stop-button"]','button[aria-label*="Stop"]','button[data-testid*="stop"]'],
     assistant: ['div[data-message-author-role="assistant"]','article [data-message-author-role="assistant"]','div[data-testid^="conversation-turn"] div[data-message-author-role="assistant"]'],
     continueLabels: ['Continue generating','Continue'],
@@ -5221,6 +5221,18 @@ function mountPanel() {
   // the natural resting state, so nothing downstream can depend on it.
   try { panel.classList.add('g-enter'); setTimeout(() => panel.classList.remove('g-enter'), 400); } catch(_) {}
   panel.addEventListener('click', _explainIntercept, true); // capture: explain mode swallows clicks before handlers
+  // Ghost controls are transport/configuration controls, never host-form
+  // submitters or anchors. Cancel only the browser's DEFAULT action on any Ghost
+  // button click (host-form submit / navigation → the reported jump-to-top on
+  // ChatGPT). We do NOT stopPropagation, so Ghost's own click handlers still run,
+  // and this covers every button across re-renders since it's delegated on the
+  // panel root. Buttons carry no meaningful default action, so this is inert
+  // except when a host form/anchor would otherwise hijack the click.
+  panel.addEventListener('click', (e) => {
+    const t = e.target;
+    const btn = t && t.closest ? t.closest('#gitl button') : null;
+    if (btn && !btn.closest('a[href]')) e.preventDefault();
+  }, true);
 }
 
 /* Escape untrusted text before interpolating into innerHTML templates.

--- a/extension/content.js
+++ b/extension/content.js
@@ -994,18 +994,12 @@ const TeachStore = {
    actuator. Each selector tier must resolve to exactly one enabled, visible,
    veto-safe element. */
 function _reviewedSend() {
-  // A human-taught send control is a reviewed actuator (the user pointed at it),
-  // valid on any host — but it is re-veto'd on every resolve by matchEl.
-  const taught = TeachStore.matchEl('send');
-  if (taught && !taught.disabled && taught.getAttribute('aria-disabled') !== 'true') return taught;
-  if (!PLAT?.reviewed) return null;
-  // Resolve the full reviewed selector set before granting authority. A page can
-  // expose two plausible controls where only one also matches a later, more
-  // specific selector. Returning that later singleton would bypass the earlier
-  // ambiguity and silently guess. Deduplicate the same DOM node across selector
-  // aliases, but fail closed if the union contains more than one safe actuator.
+  // Resolve every source of reviewed authority into one union before granting
+  // a click. This includes the selector captured by Teach mode: it was reviewed
+  // by a human when stored, but host drift can later make it match two controls.
+  // A built-in singleton must never bypass that taught-selector ambiguity.
   const candidates = new Set();
-  for (const sel of PLAT.send || []) {
+  const collect = (sel) => {
     let matches = [];
     try {
       matches = [...document.querySelectorAll(sel)].filter(el =>
@@ -1018,7 +1012,19 @@ function _reviewedSend() {
       matches = [];
     }
     for (const match of matches) candidates.add(match);
-    if (candidates.size > 1) return null;
+    return candidates.size <= 1;
+  };
+
+  const taughtSel = TeachStore.get('send');
+  if (taughtSel && !collect(taughtSel)) return null;
+  if (!PLAT?.reviewed) return candidates.size === 1 ? [...candidates][0] : null;
+
+  // A page can expose two plausible controls where only one also matches a
+  // later, more specific selector. Returning that later singleton would bypass
+  // the earlier ambiguity and silently guess. Selector aliases for the same DOM
+  // node are deduplicated by the Set.
+  for (const sel of PLAT.send || []) {
+    if (!collect(sel)) return null;
   }
   return candidates.size === 1 ? [...candidates][0] : null;
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ghost in the Loop",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "👻 AI workflow engine — fail-closed sending, validated exports, local diagnostics, and crash-safe recovery.",
   "author": "Michael S (CTRL-AI); v8.3.0 main editor Agent CG (ChatGPT)",
   "permissions": [

--- a/ghost-in-the-loop.user.js
+++ b/ghost-in-the-loop.user.js
@@ -1020,6 +1020,12 @@ function _reviewedSend() {
   const taught = TeachStore.matchEl('send');
   if (taught && !taught.disabled && taught.getAttribute('aria-disabled') !== 'true') return taught;
   if (!PLAT?.reviewed) return null;
+  // Resolve the full reviewed selector set before granting authority. A page can
+  // expose two plausible controls where only one also matches a later, more
+  // specific selector. Returning that later singleton would bypass the earlier
+  // ambiguity and silently guess. Deduplicate the same DOM node across selector
+  // aliases, but fail closed if the union contains more than one safe actuator.
+  const candidates = new Set();
   for (const sel of PLAT.send || []) {
     let matches = [];
     try {
@@ -1032,9 +1038,10 @@ function _reviewedSend() {
     } catch(_) {
       matches = [];
     }
-    if (matches.length === 1) return matches[0];
+    for (const match of matches) candidates.add(match);
+    if (candidates.size > 1) return null;
   }
-  return null;
+  return candidates.size === 1 ? [...candidates][0] : null;
 }
 
 /* ── Answer selection (v8.5.3 item 1) ────────────────────────
@@ -5242,18 +5249,6 @@ function mountPanel() {
   // the natural resting state, so nothing downstream can depend on it.
   try { panel.classList.add('g-enter'); setTimeout(() => panel.classList.remove('g-enter'), 400); } catch(_) {}
   panel.addEventListener('click', _explainIntercept, true); // capture: explain mode swallows clicks before handlers
-  // Ghost controls are transport/configuration controls, never host-form
-  // submitters or anchors. Cancel only the browser's DEFAULT action on any Ghost
-  // button click (host-form submit / navigation → the reported jump-to-top on
-  // ChatGPT). We do NOT stopPropagation, so Ghost's own click handlers still run,
-  // and this covers every button across re-renders since it's delegated on the
-  // panel root. Buttons carry no meaningful default action, so this is inert
-  // except when a host form/anchor would otherwise hijack the click.
-  panel.addEventListener('click', (e) => {
-    const t = e.target;
-    const btn = t && t.closest ? t.closest('#gitl button') : null;
-    if (btn && !btn.closest('a[href]')) e.preventDefault();
-  }, true);
 }
 
 /* Escape untrusted text before interpolating into innerHTML templates.
@@ -5874,6 +5869,11 @@ function render() {
         ${tab==='settings'?renderSettingsTab():''}
       </div>
     </div>`);
+  // Every Ghost button is a panel control, never a submitter. Declare that
+  // native semantic after each template render instead of cancelling every
+  // click's default action. This preserves normal pointer/keyboard activation
+  // and remains safe if a host later reparents the panel near a form.
+  panel.querySelectorAll('button:not([type])').forEach(button => button.setAttribute('type', 'button'));
   bindEvents();
   applyPosition(GHOST.ui.position);
 }

--- a/ghost-in-the-loop.user.js
+++ b/ghost-in-the-loop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Ghost in the Loop
 // @namespace    https://github.com/MShneur/ghost-in-the-loop
-// @version      8.8.0
+// @version      8.8.1
 // @description  👻 AI workflow engine — auto-proceed, pipelines, personas, export, diagnostics, roadmap autopilot, handoff capsules. ChatGPT · Claude · Perplexity · Gemini · DeepSeek · Copilot · Grok · Manus + 13 more.
 // @author       Michael S (CTRL-AI) — v8.3.0 main editor: Agent CG (ChatGPT); prior architecture by Claude
 // @match        https://chatgpt.com/*
@@ -102,7 +102,7 @@ try {
 /* ═══════════════════════════════════════════════════════════════
    LAYER 0 — CONSTANTS
    ═══════════════════════════════════════════════════════════════ */
-const VER = '8.8.0';
+const VER = '8.8.1';
 const SUPPORT_URL = 'https://github.com/sponsors/MShneur';
 const REPORT_REPO = 'MShneur/ghost-in-the-loop';
 
@@ -537,7 +537,7 @@ const PROFILES = {
     host: /chatgpt\.com|chat\.openai\.com/,
     label: 'ChatGPT',
     input: ['#prompt-textarea','div[contenteditable="true"][id="prompt-textarea"]','div[contenteditable="true"][data-placeholder]','textarea[data-id="root"]','textarea'],
-    send: ['button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[data-testid*="send"]','button[data-testid*="submit"]','button[class*="send"]'],
+    send: ['button[aria-label="Send message"]','button[data-testid="send-button"]','button[aria-label="Send prompt"]','button[aria-label="Send"]','form button[type="submit"]','button[data-testid*="send"]','button[data-testid*="submit"]','button[class*="send"]'],
     stop: ['button[aria-label="Stop generating"]','button[data-testid="stop-button"]','button[aria-label*="Stop"]','button[data-testid*="stop"]'],
     assistant: ['div[data-message-author-role="assistant"]','article [data-message-author-role="assistant"]','div[data-testid^="conversation-turn"] div[data-message-author-role="assistant"]'],
     continueLabels: ['Continue generating','Continue'],
@@ -5242,6 +5242,18 @@ function mountPanel() {
   // the natural resting state, so nothing downstream can depend on it.
   try { panel.classList.add('g-enter'); setTimeout(() => panel.classList.remove('g-enter'), 400); } catch(_) {}
   panel.addEventListener('click', _explainIntercept, true); // capture: explain mode swallows clicks before handlers
+  // Ghost controls are transport/configuration controls, never host-form
+  // submitters or anchors. Cancel only the browser's DEFAULT action on any Ghost
+  // button click (host-form submit / navigation → the reported jump-to-top on
+  // ChatGPT). We do NOT stopPropagation, so Ghost's own click handlers still run,
+  // and this covers every button across re-renders since it's delegated on the
+  // panel root. Buttons carry no meaningful default action, so this is inert
+  // except when a host form/anchor would otherwise hijack the click.
+  panel.addEventListener('click', (e) => {
+    const t = e.target;
+    const btn = t && t.closest ? t.closest('#gitl button') : null;
+    if (btn && !btn.closest('a[href]')) e.preventDefault();
+  }, true);
 }
 
 /* Escape untrusted text before interpolating into innerHTML templates.

--- a/ghost-in-the-loop.user.js
+++ b/ghost-in-the-loop.user.js
@@ -1015,18 +1015,12 @@ const TeachStore = {
    actuator. Each selector tier must resolve to exactly one enabled, visible,
    veto-safe element. */
 function _reviewedSend() {
-  // A human-taught send control is a reviewed actuator (the user pointed at it),
-  // valid on any host — but it is re-veto'd on every resolve by matchEl.
-  const taught = TeachStore.matchEl('send');
-  if (taught && !taught.disabled && taught.getAttribute('aria-disabled') !== 'true') return taught;
-  if (!PLAT?.reviewed) return null;
-  // Resolve the full reviewed selector set before granting authority. A page can
-  // expose two plausible controls where only one also matches a later, more
-  // specific selector. Returning that later singleton would bypass the earlier
-  // ambiguity and silently guess. Deduplicate the same DOM node across selector
-  // aliases, but fail closed if the union contains more than one safe actuator.
+  // Resolve every source of reviewed authority into one union before granting
+  // a click. This includes the selector captured by Teach mode: it was reviewed
+  // by a human when stored, but host drift can later make it match two controls.
+  // A built-in singleton must never bypass that taught-selector ambiguity.
   const candidates = new Set();
-  for (const sel of PLAT.send || []) {
+  const collect = (sel) => {
     let matches = [];
     try {
       matches = [...document.querySelectorAll(sel)].filter(el =>
@@ -1039,7 +1033,19 @@ function _reviewedSend() {
       matches = [];
     }
     for (const match of matches) candidates.add(match);
-    if (candidates.size > 1) return null;
+    return candidates.size <= 1;
+  };
+
+  const taughtSel = TeachStore.get('send');
+  if (taughtSel && !collect(taughtSel)) return null;
+  if (!PLAT?.reviewed) return candidates.size === 1 ? [...candidates][0] : null;
+
+  // A page can expose two plausible controls where only one also matches a
+  // later, more specific selector. Returning that later singleton would bypass
+  // the earlier ambiguity and silently guess. Selector aliases for the same DOM
+  // node are deduplicated by the Set.
+  for (const sel of PLAT.send || []) {
+    if (!collect(sel)) return null;
   }
   return candidates.size === 1 ? [...candidates][0] : null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-in-the-loop",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-in-the-loop",
-      "version": "8.8.0",
+      "version": "8.8.1",
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-in-the-loop",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "Ghost in the Loop — userscript, Firefox extension build, and test harness",
   "scripts": {
     "build": "npm run build:extension",

--- a/tests/build-identity.test.js
+++ b/tests/build-identity.test.js
@@ -53,7 +53,7 @@ describe('BUILD-IDENTITY oracle', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
     const current = collectCurrentIdentity(fixture, { head: HEAD_A });
-    expect(current.releaseTarget).toBe('8.8.0');
+    expect(current.releaseTarget).toBe('8.8.1');
     expect(current.channels.candidate).toBe('agent/8.8-repair-resume');
     expect(current.channels.stable).toBe('main');
     expect(current.channels.publishReady).toBe(false);
@@ -64,7 +64,7 @@ describe('BUILD-IDENTITY oracle', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
     mutateJson(path.join(fixture, 'extension/manifest.json'), (manifest) => {
-      manifest.version = '8.8.1';
+      manifest.version = '8.8.0';
     });
     expect(() => collectCurrentIdentity(fixture, { head: HEAD_A })).toThrow(/Version mismatch/);
   });

--- a/tests/chatgpt-live-hotfix.test.js
+++ b/tests/chatgpt-live-hotfix.test.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+const source = fs.readFileSync(path.join(__dirname, '../diagnostics/gitl-chatgpt-8.8-hotfix.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+function makeVisible(el) {
+  el.getBoundingClientRect = () => ({ width: 40, height: 40, top: 0, left: 0, right: 40, bottom: 40 });
+}
+
+beforeEach(() => {
+  document.documentElement.innerHTML = '<head></head><body></body>';
+  window.eval(source);
+});
+
+test('substitutes one unique semantic Send click for Ghost synthetic Enter', () => {
+  document.body.innerHTML = `
+    <div id="gitl"></div>
+    <form id="composer">
+      <div id="prompt-textarea" contenteditable="true">Continue</div>
+      <button id="send" type="button" aria-label="Send message">Send</button>
+    </form>`;
+  const composer = document.getElementById('prompt-textarea');
+  const send = document.getElementById('send');
+  makeVisible(send);
+  let clicks = 0;
+  let hostKeydowns = 0;
+  send.addEventListener('click', () => { clicks += 1; });
+  composer.addEventListener('keydown', () => { hostKeydowns += 1; });
+
+  const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+  composer.dispatchEvent(event);
+
+  expect(event.defaultPrevented).toBe(true);
+  expect(clicks).toBe(1);
+  expect(hostKeydowns).toBe(0);
+});
+
+test('fails closed when semantic Send is ambiguous', () => {
+  document.body.innerHTML = `
+    <div id="gitl"></div>
+    <form>
+      <div id="prompt-textarea" contenteditable="true">Continue</div>
+      <button id="a" type="button" aria-label="Send message">Send</button>
+      <button id="b" type="button" aria-label="Send message">Send</button>
+    </form>`;
+  const composer = document.getElementById('prompt-textarea');
+  makeVisible(document.getElementById('a'));
+  makeVisible(document.getElementById('b'));
+  let hostKeydowns = 0;
+  composer.addEventListener('keydown', () => { hostKeydowns += 1; });
+
+  const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+  composer.dispatchEvent(event);
+
+  expect(event.defaultPrevented).toBe(false);
+  expect(hostKeydowns).toBe(1);
+});
+
+test('cancels host default action on Ghost buttons without swallowing Ghost handler', () => {
+  document.body.innerHTML = '<div id="gitl"><button id="g-play">Start</button></div>';
+  const button = document.getElementById('g-play');
+  let handled = 0;
+  button.addEventListener('click', () => { handled += 1; });
+
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+  button.dispatchEvent(event);
+
+  expect(event.defaultPrevented).toBe(true);
+  expect(handled).toBe(1);
+});

--- a/tests/chatgpt-send-selector.test.js
+++ b/tests/chatgpt-send-selector.test.js
@@ -1,19 +1,13 @@
 /**
- * CHATGPT LIVE SEND SELECTOR REGRESSION (v8.8.1)
+ * CHATGPT SEND RESOLUTION REGRESSION (v8.8.1 candidate)
  *
- * Field regression after 8.8.0: on current ChatGPT the reviewed Send control
- * carries aria-label="Send message". The 8.8.0 ChatGPT adapter did NOT list
- * that identity, so _reviewedSend() returned null, engineSend selected the
- * reviewed synthetic-Enter fallback, and current ChatGPT ignored the synthetic
- * key event — the continuation text was inserted but never sent.
+ * The authenticated field failure remains unverified in this harness. These
+ * fixtures lock down two bounded facts instead:
+ *   - the production adapter can recognize a possible `Send message` variant;
+ *   - all reviewed selector aliases must resolve to one unique DOM node before
+ *     Ghost receives click authority.
  *
- * This proves the PRODUCTION adapter (not the diagnostic field shim) resolves
- * the real button as a single reviewed actuator, preserving at-most-once
- * dispatch and all existing send vetoes / fail-closed behaviour. The harness
- * boots with location.hostname = chatgpt.com, so PLAT is the ChatGPT adapter.
- *
- * Symbols (_reviewedSend, SEND_VETO, _sendLooksSafe, TeachStore) arrive on
- * global via tests/setup.js.
+ * Symbols arrive on global via tests/setup.js, whose URL selects ChatGPT.
  */
 const fs = require('fs');
 const path = require('path');
@@ -24,91 +18,128 @@ function chatgptProfile() {
   return src.slice(start, src.indexOf('\n  perplexity:', start));
 }
 
+function sendBtn(label, extra = {}, visible = true) {
+  const button = document.createElement('button');
+  if (label != null) button.setAttribute('aria-label', label);
+  button.textContent = label || '';
+  Object.entries(extra).forEach(([key, value]) => button.setAttribute(key, value));
+  button.getBoundingClientRect = () => visible
+    ? ({ width: 40, height: 40, top: 10, left: 0, right: 40, bottom: 50 })
+    : ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 });
+  return button;
+}
+
 describe('ChatGPT reviewed Send — source contract', () => {
   const profile = chatgptProfile();
 
-  test('lists the current-live aria-label="Send message" identity', () => {
+  test('includes the bounded Send message compatibility identity', () => {
     expect(profile).toContain(`'button[aria-label="Send message"]'`);
   });
 
-  test('prefers the semantic Send identity over the generic form-submit fallback', () => {
-    // Order matters in _reviewedSend: the first selector that resolves to a
-    // single safe match wins. The confirmed live identity must be tried before
-    // the broad `form button[type="submit"]` that masked the gap in fixtures.
+  test('retains the identities observed on the current signed-out public composer', () => {
+    expect(profile).toContain(`'button[data-testid="send-button"]'`);
+    expect(profile).toContain(`'button[aria-label="Send prompt"]'`);
+  });
+
+  test('reviewed semantic identities precede the generic form-submit fallback', () => {
     const semanticAt = profile.indexOf(`aria-label="Send message"`);
     const submitAt = profile.indexOf(`form button[type="submit"]`);
     expect(semanticAt).toBeGreaterThan(-1);
     expect(submitAt).toBeGreaterThan(semanticAt);
   });
 
-  test('"Send message" is not caught by the send veto', () => {
+  test('Send message is not caught by the send veto', () => {
     expect(SEND_VETO.test('Send message')).toBe(false);
-    expect(_sendLooksSafe({ getAttribute: (k) => (k === 'aria-label' ? 'Send message' : null), textContent: '' })).toBe(true);
+    expect(_sendLooksSafe({
+      getAttribute: (key) => (key === 'aria-label' ? 'Send message' : null),
+      textContent: ''
+    })).toBe(true);
   });
 });
 
-describe('_reviewedSend resolves the real ChatGPT Send button (live DOM)', () => {
-  function sendBtn(label, extra = {}) {
-    const b = document.createElement('button');
-    if (label != null) b.setAttribute('aria-label', label);
-    b.textContent = label || '';
-    Object.entries(extra).forEach(([k, v]) => b.setAttribute(k, v));
-    // jsdom returns a zero rect; make it pass the visibility gate.
-    b.getBoundingClientRect = () => ({ width: 40, height: 40, top: 10, left: 0, right: 40, bottom: 50 });
-    return b;
-  }
-
+describe('_reviewedSend fixture resolution', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
     try { TeachStore.forgetHost(); } catch (_) {}
   });
 
-  test('a unique visible aria-label="Send message" is returned as the reviewed actuator', () => {
-    const b = sendBtn('Send message');
-    document.body.appendChild(b);
-    expect(_reviewedSend()).toBe(b);
+  test('a unique visible Send message variant resolves to its exact node', () => {
+    const button = sendBtn('Send message');
+    document.body.appendChild(button);
+    expect(_reviewedSend()).toBe(button);
   });
 
-  test('two plausible Send controls are ambiguous → fail closed (null, never a guess)', () => {
+  test('the current signed-out public composer identity resolves without Send message', () => {
+    const form = document.createElement('form');
+    const button = sendBtn('Send prompt', {
+      id: 'composer-submit-button',
+      'data-testid': 'send-button'
+    });
+    form.appendChild(button);
+    document.body.appendChild(form);
+
+    expect(button.getAttribute('type')).toBeNull();
+    expect(_reviewedSend()).toBe(button);
+  });
+
+  test('selector aliases for the same node are deduplicated', () => {
+    const button = sendBtn('Send message', { 'data-testid': 'send-button' });
+    document.body.appendChild(button);
+    expect(_reviewedSend()).toBe(button);
+  });
+
+  test('two plausible Send controls are ambiguous and fail closed', () => {
     document.body.appendChild(sendBtn('Send message'));
     document.body.appendChild(sendBtn('Send message'));
     expect(_reviewedSend()).toBeNull();
   });
 
-  test('a disabled Send message is never actuated', () => {
-    const b = sendBtn('Send message');
-    b.disabled = true;
-    document.body.appendChild(b);
+  test('ambiguity cannot be bypassed by a later selector matching one duplicate', () => {
+    document.body.appendChild(sendBtn('Send message', { 'data-testid': 'send-button' }));
+    document.body.appendChild(sendBtn('Send message'));
     expect(_reviewedSend()).toBeNull();
   });
 
-  test('a menu/attach decoy labelled Send is vetoed by the structural gate', () => {
-    document.body.appendChild(sendBtn('Send message', { 'aria-haspopup': 'menu' }));
+  test('a hidden secondary control does not make the visible composer ambiguous', () => {
+    const visible = sendBtn('Send prompt', { 'data-testid': 'send-button' });
+    document.body.appendChild(visible);
+    document.body.appendChild(sendBtn('Send message', {}, false));
+    expect(_reviewedSend()).toBe(visible);
+  });
+
+  test('resolution is fresh after the host replaces the Send node', () => {
+    const first = sendBtn('Send message');
+    document.body.appendChild(first);
+    expect(_reviewedSend()).toBe(first);
+
+    const replacement = sendBtn('Send message');
+    first.replaceWith(replacement);
+    expect(_reviewedSend()).toBe(replacement);
+  });
+
+  test.each([
+    ['disabled', (button) => { button.disabled = true; }],
+    ['aria-disabled', (button) => { button.setAttribute('aria-disabled', 'true'); }],
+    ['menu popup', (button) => { button.setAttribute('aria-haspopup', 'menu'); }],
+    ['disclosure', (button) => { button.setAttribute('aria-expanded', 'false'); }]
+  ])('rejects a %s Send decoy', (_name, mutate) => {
+    const button = sendBtn('Send message');
+    mutate(button);
+    document.body.appendChild(button);
     expect(_reviewedSend()).toBeNull();
   });
 });
 
-describe('Ghost-button default-action guard (scroll-to-top symptom)', () => {
-  // mountPanel installs a panel-scoped, capture-phase guard that cancels the
-  // browser DEFAULT action on Ghost button clicks (host-form submit / anchor
-  // navigation → the reported jump-to-top) WITHOUT stopping propagation, so
-  // Ghost's own click handlers still fire and every re-rendered button is
-  // covered by the single delegated listener.
-  // Scope to the guard block itself: from its anchor comment to the end of the
-  // listener registration, so the assertion can't leak into neighbouring code.
-  // Anchor on the guard's CODE (not its comment, which mentions the words) so
-  // the propagation assertion reflects the actual listener body.
-  const codeAt = src.indexOf("const btn = t && t.closest ? t.closest('#gitl button')");
-  const guard = src.slice(codeAt, src.indexOf('}, true);', codeAt));
-
-  test('mountPanel prevents default on Ghost button clicks', () => {
-    expect(codeAt).toBeGreaterThan(-1);
-    expect(guard).toContain("closest('#gitl button')");
-    expect(guard).toContain('e.preventDefault()');
+describe('Ghost button semantics', () => {
+  test('render normalizes every panel button to type=button', () => {
+    expect(src).toContain("panel.querySelectorAll('button:not([type])')");
+    expect(src).toContain("button.setAttribute('type', 'button')");
   });
 
-  test('the guard never stops propagation (Ghost handlers must still run)', () => {
-    expect(guard).not.toContain('stopPropagation');
-    expect(guard).not.toContain('stopImmediatePropagation');
+  test('mountPanel does not globally cancel ordinary Ghost clicks', () => {
+    const start = src.indexOf('function mountPanel()');
+    const block = src.slice(start, src.indexOf('function _esc', start));
+    expect(block).not.toContain("closest('#gitl button')");
+    expect(block).not.toContain('e.preventDefault()');
   });
 });

--- a/tests/chatgpt-send-selector.test.js
+++ b/tests/chatgpt-send-selector.test.js
@@ -100,6 +100,19 @@ describe('_reviewedSend fixture resolution', () => {
     expect(_reviewedSend()).toBeNull();
   });
 
+  test('an ambiguous taught selector cannot bypass exact-one authority through a reviewed alias', () => {
+    const reviewed = sendBtn('Send message', {
+      class: 'taught-send',
+      'data-testid': 'send-button'
+    });
+    const alternate = sendBtn('Deliver', { class: 'taught-send' });
+    document.body.appendChild(reviewed);
+    document.body.appendChild(alternate);
+    TeachStore.set('send', 'button.taught-send');
+
+    expect(_reviewedSend()).toBeNull();
+  });
+
   test('a hidden secondary control does not make the visible composer ambiguous', () => {
     const visible = sendBtn('Send prompt', { 'data-testid': 'send-button' });
     document.body.appendChild(visible);

--- a/tests/chatgpt-send-selector.test.js
+++ b/tests/chatgpt-send-selector.test.js
@@ -1,0 +1,114 @@
+/**
+ * CHATGPT LIVE SEND SELECTOR REGRESSION (v8.8.1)
+ *
+ * Field regression after 8.8.0: on current ChatGPT the reviewed Send control
+ * carries aria-label="Send message". The 8.8.0 ChatGPT adapter did NOT list
+ * that identity, so _reviewedSend() returned null, engineSend selected the
+ * reviewed synthetic-Enter fallback, and current ChatGPT ignored the synthetic
+ * key event — the continuation text was inserted but never sent.
+ *
+ * This proves the PRODUCTION adapter (not the diagnostic field shim) resolves
+ * the real button as a single reviewed actuator, preserving at-most-once
+ * dispatch and all existing send vetoes / fail-closed behaviour. The harness
+ * boots with location.hostname = chatgpt.com, so PLAT is the ChatGPT adapter.
+ *
+ * Symbols (_reviewedSend, SEND_VETO, _sendLooksSafe, TeachStore) arrive on
+ * global via tests/setup.js.
+ */
+const fs = require('fs');
+const path = require('path');
+const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
+
+function chatgptProfile() {
+  const start = src.indexOf('chatgpt: {');
+  return src.slice(start, src.indexOf('\n  perplexity:', start));
+}
+
+describe('ChatGPT reviewed Send — source contract', () => {
+  const profile = chatgptProfile();
+
+  test('lists the current-live aria-label="Send message" identity', () => {
+    expect(profile).toContain(`'button[aria-label="Send message"]'`);
+  });
+
+  test('prefers the semantic Send identity over the generic form-submit fallback', () => {
+    // Order matters in _reviewedSend: the first selector that resolves to a
+    // single safe match wins. The confirmed live identity must be tried before
+    // the broad `form button[type="submit"]` that masked the gap in fixtures.
+    const semanticAt = profile.indexOf(`aria-label="Send message"`);
+    const submitAt = profile.indexOf(`form button[type="submit"]`);
+    expect(semanticAt).toBeGreaterThan(-1);
+    expect(submitAt).toBeGreaterThan(semanticAt);
+  });
+
+  test('"Send message" is not caught by the send veto', () => {
+    expect(SEND_VETO.test('Send message')).toBe(false);
+    expect(_sendLooksSafe({ getAttribute: (k) => (k === 'aria-label' ? 'Send message' : null), textContent: '' })).toBe(true);
+  });
+});
+
+describe('_reviewedSend resolves the real ChatGPT Send button (live DOM)', () => {
+  function sendBtn(label, extra = {}) {
+    const b = document.createElement('button');
+    if (label != null) b.setAttribute('aria-label', label);
+    b.textContent = label || '';
+    Object.entries(extra).forEach(([k, v]) => b.setAttribute(k, v));
+    // jsdom returns a zero rect; make it pass the visibility gate.
+    b.getBoundingClientRect = () => ({ width: 40, height: 40, top: 10, left: 0, right: 40, bottom: 50 });
+    return b;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    try { TeachStore.forgetHost(); } catch (_) {}
+  });
+
+  test('a unique visible aria-label="Send message" is returned as the reviewed actuator', () => {
+    const b = sendBtn('Send message');
+    document.body.appendChild(b);
+    expect(_reviewedSend()).toBe(b);
+  });
+
+  test('two plausible Send controls are ambiguous → fail closed (null, never a guess)', () => {
+    document.body.appendChild(sendBtn('Send message'));
+    document.body.appendChild(sendBtn('Send message'));
+    expect(_reviewedSend()).toBeNull();
+  });
+
+  test('a disabled Send message is never actuated', () => {
+    const b = sendBtn('Send message');
+    b.disabled = true;
+    document.body.appendChild(b);
+    expect(_reviewedSend()).toBeNull();
+  });
+
+  test('a menu/attach decoy labelled Send is vetoed by the structural gate', () => {
+    document.body.appendChild(sendBtn('Send message', { 'aria-haspopup': 'menu' }));
+    expect(_reviewedSend()).toBeNull();
+  });
+});
+
+describe('Ghost-button default-action guard (scroll-to-top symptom)', () => {
+  // mountPanel installs a panel-scoped, capture-phase guard that cancels the
+  // browser DEFAULT action on Ghost button clicks (host-form submit / anchor
+  // navigation → the reported jump-to-top) WITHOUT stopping propagation, so
+  // Ghost's own click handlers still fire and every re-rendered button is
+  // covered by the single delegated listener.
+  // Scope to the guard block itself: from its anchor comment to the end of the
+  // listener registration, so the assertion can't leak into neighbouring code.
+  // Anchor on the guard's CODE (not its comment, which mentions the words) so
+  // the propagation assertion reflects the actual listener body.
+  const codeAt = src.indexOf("const btn = t && t.closest ? t.closest('#gitl button')");
+  const guard = src.slice(codeAt, src.indexOf('}, true);', codeAt));
+
+  test('mountPanel prevents default on Ghost button clicks', () => {
+    expect(codeAt).toBeGreaterThan(-1);
+    expect(guard).toContain("closest('#gitl button')");
+    expect(guard).toContain('e.preventDefault()');
+  });
+
+  test('the guard never stops propagation (Ghost handlers must still run)', () => {
+    expect(guard).not.toContain('stopPropagation');
+    expect(guard).not.toContain('stopImmediatePropagation');
+  });
+});

--- a/tests/e2e/chatgpt-live-regression.spec.js
+++ b/tests/e2e/chatgpt-live-regression.spec.js
@@ -1,0 +1,178 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Deterministic regression coverage for the ChatGPT 8.8 field report.
+ *
+ * This fixture uses DOM facts observed on the current signed-out public
+ * ChatGPT composer. It is not an authenticated-live certification.
+ */
+const RAW = fs.readFileSync(path.join(__dirname, '../../ghost-in-the-loop.user.js'), 'utf8')
+  .replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/m, '');
+
+const EXPOSE = `
+  window.__GITL_ReviewedSend = () => _reviewedSend();
+`;
+
+const SCRIPT = /\n\} catch\(__gitlBootErr\)/.test(RAW)
+  ? RAW.replace(/\n\} catch\(__gitlBootErr\)/, '\n' + EXPOSE + '\n} catch(__gitlBootErr)')
+  : RAW.replace(/(\}\)\(\)\s*;?\s*)$/, EXPOSE + '\n$1');
+
+const GM = `
+  window.__gmStore = { panelCollapsed: false, panelPosition: 'top-right' };
+  window.GM_getValue = (key, fallback) => (
+    window.__gmStore[key] !== undefined ? window.__gmStore[key] : fallback
+  );
+  window.GM_setValue = (key, value) => { window.__gmStore[key] = value; };
+  window.GM_addStyle = (css) => {
+    const style = document.createElement('style');
+    style.textContent = css;
+    (document.head || document.documentElement).appendChild(style);
+  };
+  window.GM_setClipboard = () => {};
+  window.GM_notification = () => {};
+`;
+
+const FIXTURE = `<!doctype html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+    body { margin: 0; min-height: 5200px; font: 14px system-ui; }
+    #probe-anchor { position: absolute; top: 2100px; }
+    #composer-wrap { position: absolute; top: 4700px; left: 20%; width: 60%; }
+    #prompt-textarea { min-height: 48px; border: 1px solid #999; }
+    #composer-submit-button { width: 40px; height: 40px; }
+    #hidden-composer { display: none; }
+  </style>
+</head>
+<body>
+  <div id="probe-anchor">scroll probe</div>
+  <div id="composer-wrap">
+    <form id="composer" data-type="unified-composer">
+      <textarea aria-label="Chat with ChatGPT" hidden></textarea>
+      <div id="prompt-textarea" role="textbox" contenteditable="true" aria-label="Chat with ChatGPT"></div>
+      <button id="composer-submit-button" data-testid="send-button" aria-label="Send prompt">Send</button>
+    </form>
+    <div id="hidden-composer">
+      <button aria-label="Send message">Hidden Send</button>
+    </div>
+  </div>
+  <script>
+    window.__hostProbe = { submits: 0, hashChanges: 0, sendClicks: 0 };
+    document.getElementById('composer').addEventListener('submit', (event) => {
+      window.__hostProbe.submits += 1;
+      event.preventDefault();
+    });
+    document.getElementById('composer-submit-button').addEventListener('click', () => {
+      window.__hostProbe.sendClicks += 1;
+    });
+    window.addEventListener('hashchange', () => { window.__hostProbe.hashChanges += 1; });
+  </script>
+</body>
+</html>`;
+
+async function boot(page) {
+  await page.route('https://chatgpt.com/**', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: FIXTURE
+  }));
+  await page.addInitScript(GM);
+  await page.addInitScript(SCRIPT);
+  await page.goto('https://chatgpt.com/gitl-regression#field-probe');
+  await expect(page.locator('#gitl')).toBeVisible({ timeout: 5000 });
+  await expect.poll(() => page.locator('html').getAttribute('data-gitl-boot')).toMatch(/^ok:/);
+}
+
+test.describe('ChatGPT 8.8 regression fixture', () => {
+  test('current public Send prompt identity resolves to the exact unmodified host node', async ({ page }) => {
+    await boot(page);
+
+    const resolved = await page.evaluate(() => {
+      const chosen = window.__GITL_ReviewedSend();
+      const host = document.getElementById('composer-submit-button');
+      return {
+        sameNode: chosen === host,
+        id: chosen && chosen.id,
+        label: chosen && chosen.getAttribute('aria-label'),
+        testId: chosen && chosen.getAttribute('data-testid'),
+        type: chosen && chosen.getAttribute('type'),
+        sendClicks: window.__hostProbe.sendClicks,
+        submits: window.__hostProbe.submits
+      };
+    });
+
+    expect(resolved).toEqual({
+      sameNode: true,
+      id: 'composer-submit-button',
+      label: 'Send prompt',
+      testId: 'send-button',
+      type: null,
+      sendClicks: 0,
+      submits: 0
+    });
+  });
+
+  test('a visible alternate Send identity makes actuator authority ambiguous', async ({ page }) => {
+    await boot(page);
+
+    const result = await page.evaluate(() => {
+      const duplicate = document.createElement('button');
+      duplicate.setAttribute('aria-label', 'Send message');
+      duplicate.textContent = 'Alternate Send';
+      duplicate.style.cssText = 'position:fixed;left:8px;bottom:8px;width:80px;height:40px';
+      document.body.appendChild(duplicate);
+      return {
+        resolved: window.__GITL_ReviewedSend() !== null,
+        sendClicks: window.__hostProbe.sendClicks,
+        submits: window.__hostProbe.submits
+      };
+    });
+
+    expect(result).toEqual({ resolved: false, sendClicks: 0, submits: 0 });
+  });
+
+  test('Adaptive and committee controls mutate Ghost only, without form, URL, hash, or scroll side effects', async ({ page }) => {
+    await boot(page);
+    await page.evaluate(() => window.scrollTo(0, 2100));
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(2100);
+
+    const before = await page.evaluate(() => ({
+      url: location.href,
+      hash: location.hash,
+      scrollY: window.scrollY,
+      panelInForm: Boolean(document.getElementById('gitl').closest('form'))
+    }));
+
+    await page.locator('#run-adv').click();
+    await page.locator('.g-pst[data-pst="evolving"]').click();
+    await page.locator('#g-committee-p').click();
+
+    const after = await page.evaluate(() => ({
+      url: location.href,
+      hash: location.hash,
+      scrollY: window.scrollY,
+      panelInForm: Boolean(document.getElementById('gitl').closest('form')),
+      buttonTypes: [...document.querySelectorAll('#gitl button')].map(button => button.type),
+      runAdv: window.__gmStore.runAdv,
+      posture: window.__gmStore.posture,
+      committeeProceed: window.__gmStore.committeeProceed,
+      host: { ...window.__hostProbe }
+    }));
+
+    expect(before.panelInForm).toBe(false);
+    expect(after.panelInForm).toBe(false);
+    expect(after.buttonTypes.length).toBeGreaterThan(0);
+    expect(new Set(after.buttonTypes)).toEqual(new Set(['button']));
+    expect(after.runAdv).toBe(true);
+    expect(after.posture).toBe('evolving');
+    expect(after.committeeProceed).toBe(true);
+    expect(after.host).toEqual({ submits: 0, hashChanges: 0, sendClicks: 0 });
+    expect(after.url).toBe(before.url);
+    expect(after.hash).toBe(before.hash);
+    expect(Math.abs(after.scrollY - before.scrollY)).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/e2e/chatgpt-live-regression.spec.js
+++ b/tests/e2e/chatgpt-live-regression.spec.js
@@ -90,6 +90,8 @@ async function boot(page) {
 test.describe('ChatGPT 8.8 regression fixture', () => {
   test('current public Send prompt identity resolves to the exact unmodified host node', async ({ page }) => {
     await boot(page);
+    await page.locator('#composer-submit-button').scrollIntoViewIfNeeded();
+    await expect(page.locator('#composer-submit-button')).toBeVisible();
 
     const resolved = await page.evaluate(() => {
       const chosen = window.__GITL_ReviewedSend();
@@ -118,6 +120,8 @@ test.describe('ChatGPT 8.8 regression fixture', () => {
 
   test('a visible alternate Send identity makes actuator authority ambiguous', async ({ page }) => {
     await boot(page);
+    await page.locator('#composer-submit-button').scrollIntoViewIfNeeded();
+    await expect(page.locator('#composer-submit-button')).toBeVisible();
 
     const result = await page.evaluate(() => {
       const duplicate = document.createElement('button');

--- a/tests/e2e/teach.spec.js
+++ b/tests/e2e/teach.spec.js
@@ -76,6 +76,39 @@ test.describe('Teach mode', () => {
     expect(result.controlFired).toBe(false);       // teaching never triggered the control
   });
 
+  test('a taught selector that drifts to two visible controls fails closed', async ({ page }) => {
+    await page.addInitScript(GM);
+    await page.addInitScript(SCRIPT);
+    await page.goto(PAGE);
+    await page.waitForTimeout(700);
+
+    const result = await page.evaluate(() => {
+      const original = document.getElementById('odd-send');
+      window.__GITL_Teach.arm('send');
+      original.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
+      const uniqueBeforeDrift = window.__GITL_Adapter.getSendBtn();
+
+      // Model a host rerender that temporarily leaves two nodes matching the
+      // selector captured when the original control was unique.
+      const duplicate = original.cloneNode(true);
+      duplicate.textContent = 'Alternate send';
+      original.after(duplicate);
+      const afterDrift = window.__GITL_Adapter.getSendBtn();
+
+      return {
+        captured: window.__GITL_TeachStore.get('send'),
+        uniqueBeforeDrift: uniqueBeforeDrift === original,
+        matchingNodes: document.querySelectorAll(window.__GITL_TeachStore.get('send')).length,
+        resolvedAfterDrift: afterDrift ? afterDrift.id : null
+      };
+    });
+
+    expect(result.captured).toBeTruthy();
+    expect(result.uniqueBeforeDrift).toBe(true);
+    expect(result.matchingNodes).toBe(2);
+    expect(result.resolvedAfterDrift).toBeNull();
+  });
+
   test('tapping a popup-toggle is vetoed — nothing is stored', async ({ page }) => {
     await page.addInitScript(GM);
     await page.addInitScript(SCRIPT);

--- a/tests/package-candidate.test.js
+++ b/tests/package-candidate.test.js
@@ -109,7 +109,7 @@ describe('release candidate package oracle', () => {
   test('kills release version drift', () => {
     const root = copyFixture();
     roots.push(root);
-    mutateJson(root, 'package.json', (pkg) => { pkg.version = '8.8.1'; });
+    mutateJson(root, 'package.json', (pkg) => { pkg.version = '8.8.0'; });
     expect(() => writePackage(root)).toThrow(/Version mismatch|Release target drift/);
   });
 

--- a/tests/sendtransaction.test.js
+++ b/tests/sendtransaction.test.js
@@ -18,9 +18,11 @@ function body(name, nextName) {
 describe('dispatch authority', () => {
   test('only reviewed platform selectors may return a button actuator', () => {
     expect(src).toContain('function _reviewedSend()');
-    expect(src).toContain('if (!PLAT?.reviewed) return null;');
     expect(src).toContain('const candidates = new Set();');
-    expect(src).toContain('if (candidates.size > 1) return null;');
+    expect(src).toContain("const taughtSel = TeachStore.get('send');");
+    expect(src).toContain('if (taughtSel && !collect(taughtSel)) return null;');
+    expect(src).toContain('if (!PLAT?.reviewed) return candidates.size === 1 ? [...candidates][0] : null;');
+    expect(src).toContain('if (!collect(sel)) return null;');
     expect(src).toContain("return candidates.size === 1 ? [...candidates][0] : null;");
   });
 

--- a/tests/sendtransaction.test.js
+++ b/tests/sendtransaction.test.js
@@ -19,7 +19,9 @@ describe('dispatch authority', () => {
   test('only reviewed platform selectors may return a button actuator', () => {
     expect(src).toContain('function _reviewedSend()');
     expect(src).toContain('if (!PLAT?.reviewed) return null;');
-    expect(src).toContain('if (matches.length === 1) return matches[0];');
+    expect(src).toContain('const candidates = new Set();');
+    expect(src).toContain('if (candidates.size > 1) return null;');
+    expect(src).toContain("return candidates.size === 1 ? [...candidates][0] : null;");
   });
 
   test('generic and imported custom adapters are not reviewed actuators', () => {

--- a/tests/teach.test.js
+++ b/tests/teach.test.js
@@ -40,12 +40,13 @@ describe('wiring — taught controls are consulted (source contract)', () => {
   const fs = require('fs'), path = require('path');
   const src = fs.readFileSync(path.join(__dirname, '../ghost-in-the-loop.user.js'), 'utf8');
 
-  test('_reviewedSend consults a taught send BEFORE the reviewed-platform gate', () => {
-    const fn = src.slice(src.indexOf('function _reviewedSend()'), src.indexOf('function _reviewedSend()') + 400);
-    const taughtAt = fn.indexOf("TeachStore.matchEl('send')");
-    const gateAt = fn.indexOf('if (!PLAT?.reviewed) return null;');
+  test('_reviewedSend unions a taught send BEFORE the reviewed-platform gate', () => {
+    const fn = src.slice(src.indexOf('function _reviewedSend()'), src.indexOf('function _reviewedSend()') + 1800);
+    const taughtAt = fn.indexOf("TeachStore.get('send')");
     expect(taughtAt).toBeGreaterThan(-1);
-    expect(gateAt).toBeGreaterThan(taughtAt);
+    expect(fn).toContain('if (taughtSel && !collect(taughtSel)) return null;');
+    expect(fn).toContain('if (!PLAT?.reviewed) return candidates.size === 1 ? [...candidates][0] : null;');
+    expect(fn.indexOf('if (!PLAT?.reviewed)')).toBeGreaterThan(taughtAt);
   });
 
   test('peekInput consults a taught input', () => {


### PR DESCRIPTION
## Field facts

After 8.8.0 on authenticated ChatGPT, Ghost inserted continuation text but did not send it; Adaptive/committee controls also appeared to jump the page toward the top. Those observations remain field facts.

## Evidence correction

The earlier PR body called `aria-label="Send message"` the proven current-live root cause. That exceeded the evidence.

A read-only probe of today's **signed-out public** ChatGPT composer revealed one conditional Send node after typing:

- `button#composer-submit-button`
- `aria-label="Send prompt"`
- `data-testid="send-button"`
- no explicit `type`
- visible/enabled inside the composer form

Both identities were already reviewed in 8.8.0. The unsent probe was cleared and Send was not actuated. This falsifies the universal/current-layout claim; it does not rule out an authenticated/mobile/experiment variant using `Send message`. The reporter's failing authenticated DOM was not captured, so the field root cause remains **UNKNOWN**.

## Smallest bounded production candidate

- Retain `button[aria-label="Send message"]` only as a reviewed compatibility identity, not a certified root-cause fix.
- Resolve every eligible built-in reviewed selector and human-taught Send selector into one deduplicated `Set`. Grant click authority only when the complete union contains exactly one DOM node.
  - This closes the earlier cross-selector bypass.
  - It also closes a newly reproduced taught-selector bypass: a selector that drifted to two visible controls previously returned its first match even when only one also matched a built-in alias.
- Preserve the at-most-once transaction: select one actuator before the journal, actuate once, observe confirmation, otherwise enter uncertainty/manual recovery. No requestSubmit/Enter/click escalation was added.
- Remove the unproven panel-wide click `preventDefault()` interceptor. `#gitl` mounts under `body`, outside host forms and anchors. Normalize every rendered Ghost button to `type="button"` instead.
- Keep the diagnostic shim as a temporary probe, not production architecture.

## Regression coverage

- Unit fixtures: public `Send prompt` shape, possible `Send message` variant, same-node alias deduplication, cross-selector and taught-selector ambiguity, hidden/disabled/`aria-disabled`/menu/disclosure decoys, and replaced nodes.
- Transaction contract: one complete exact-one authority union with one selected dispatch.
- Real-browser fixtures:
  - exact host Send node remains unchanged;
  - visible alternate Send fails closed;
  - a uniquely taught actuator works on an unreviewed host, then fails closed after two-node selector drift;
  - Adaptive/committee controls mutate intended Ghost state;
  - every Ghost button is `type=button`;
  - no host submit, Send click, URL/hash mutation, or scroll movement.

## Exact verification

Current documentation head: `92f24147d789c7ae5589c6052e30badcafa6c3c8`.
Code-bearing head: `275919c0e78312e2ed9bfd03f0422faddd90c2b0`.

Code-bearing GitHub Actions run [31624115333](https://github.com/MShneur/ghost-in-the-loop/actions/runs/31624115333) completed **success**:

- Unit/base job `94206004939`: Node 20.20.2, npm 10.8.2; 47 suites / 514 passed / 3 todo; generated parity, syntax, base certification, BUILD-IDENTITY (`head-moved-payload-identical`, `publishReady:false`) and packaging passed.
- Playwright job `94206004903`: 239 cases; **229 passed / 10 skipped** across Chromium, Firefox and selected mobile lanes. The taught-selector drift test passed in Chromium and Firefox, as did all six ChatGPT Send/control executions.
- Candidate `SHA256SUMS`: `8469497e85bd2a1f1b78aac96a2f8c7cfe8e4d9b31f952492e944d551ecf7284`.
- Artifacts: package `9152416065`, base certification `9152416779`, E2E `9152546359`.

Current-head run [31624699175](https://github.com/MShneur/ghost-in-the-loop/actions/runs/31624699175) is **red on one pre-existing wall-clock performance assertion**:

- Unit/base job `94209562846`: success, same 514 passed / 3 todo and package hash.
- E2E initial attempt: 228 passed / 10 skipped; only `tests/e2e/long-chat-perf-a2.spec.js` failed at 5.3 ms, then 2.300000000002 ms against strict `<2.3 ms`.
- One guarded rerun, job `94209561784`: again 228 passed / 10 skipped; the same assertion measured 2.300000000017 ms, then 3.0 ms.
- The only tree difference from the fully green code-bearing head is this handoff document. No product or test bytes changed. The accepted threshold was not weakened, and no further rerun was attempted.

Local Node 24 evidence: 47 suites / 514 passed / 3 todo; syntax, generated parity, base certification, identity and packaging passed; production dependency audit reported zero vulnerabilities. Local Playwright could not start because browser binaries were unavailable and the permitted download returned 0 MiB/truncated archives.

## Release boundary

This PR is **not authenticated-live certified** and the current head is **not fully CI-green** because of the preserved timing gate above. Do not call it a proven field repair or publish-ready release.

The reporter's canary remains required: intended Ghost state mutation → prompt injection → exact real Send activation → one outbound turn → generation begins → one continuation → no duplicate and no scroll jump.

Do not merge, auto-merge, tag, publish, create a Release, or change the stable userscript channel as part of this investigation.