### PR TITLE
Certify the committed extension artifact instead of a regenerated one

### DIFF
--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -196,10 +196,11 @@ jobs:
         run: npm ci
 
       # Fail closed on a stale artifact instead of silently rebuilding it
-      # mid-release: publish the bytes that were reviewed at $TARGET_SHA.
+      # mid-release. HEAD is asserted to be $TARGET_SHA above, so reading blobs
+      # certifies exactly the bytes that were reviewed there.
       - name: Verify committed extension artifact matches source
         if: steps.gate.outputs.release_exists != 'true'
-        run: npm run check:generated
+        run: npm run check:committed
 
       - name: Certify release payload
         if: steps.gate.outputs.release_exists != 'true'

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -209,6 +209,7 @@ jobs:
           npm run test:unit
           npm run identity:oracle
           npm run package:oracle
+          npm run check:clean-tree
 
       - name: Externalize certified release assets before E2E workspace cleanup
         if: steps.gate.outputs.release_exists != 'true'

--- a/.github/workflows/publish-final-release.yml
+++ b/.github/workflows/publish-final-release.yml
@@ -195,7 +195,13 @@ jobs:
         if: steps.gate.outputs.release_exists != 'true'
         run: npm ci
 
-      - name: Build and certify release payload
+      # Fail closed on a stale artifact instead of silently rebuilding it
+      # mid-release: publish the bytes that were reviewed at $TARGET_SHA.
+      - name: Verify committed extension artifact matches source
+        if: steps.gate.outputs.release_exists != 'true'
+        run: npm run check:generated
+
+      - name: Certify release payload
         if: steps.gate.outputs.release_exists != 'true'
         run: |
           npm run cert:base

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,11 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      # Parity must be checked on the committed bytes, before any step can
-      # rewrite them — that artifact is what a clone/zip install actually runs.
+      # Parity is checked on the committed bytes — that artifact is what a
+      # clone/zip install actually runs. Reading blobs rather than the working
+      # tree keeps the gate honest wherever this step sits in the job.
       - name: Verify committed extension artifact matches source
-        run: npm run check:generated
+        run: npm run check:committed
       - name: Certify extension artifacts
         run: npm run cert:base
       # Guards the invariant rather than one ordering mistake: if any cert step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
         run: npm run check:generated
       - name: Certify extension artifacts
         run: npm run cert:base
+      # Guards the invariant rather than one ordering mistake: if any cert step
+      # ever rewrites the artifact again, this fails instead of hiding it.
+      - name: Assert certification did not mutate the artifact
+        run: npm run check:clean-tree
       - name: Syntax checks
         run: npm run lint
       - name: Run unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Build and certify extension artifacts
+      # Parity must be checked on the committed bytes, before any step can
+      # rewrite them — that artifact is what a clone/zip install actually runs.
+      - name: Verify committed extension artifact matches source
+        run: npm run check:generated
+      - name: Certify extension artifacts
         run: npm run cert:base
       - name: Syntax checks
         run: npm run lint

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cert:preflight": "node scripts/certify-extension.js preflight",
     "cert:manifest-audit": "node scripts/certify-extension.js manifest",
     "cert:artifact-index": "node scripts/certify-extension.js artifacts --out test-results/extension-artifact-index.json",
-    "cert:base": "npm run cert:preflight && npm run build:extension && npm run check:generated && npm run cert:manifest-audit && npm run cert:artifact-index",
+    "cert:base": "npm run cert:preflight && npm run check:generated && npm run cert:manifest-audit && npm run cert:artifact-index",
     "identity:write": "node scripts/build-identity.js --write .gitl/evidence/round-7/candidate-identity.json",
     "identity:check": "node scripts/build-identity.js --check .gitl/evidence/round-7/candidate-identity.json",
     "identity:oracle": "npm run cert:base && npx jest tests/version.test.js tests/build-identity.test.js --runInBand && npm run identity:check",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "npm run build:extension",
     "build:extension": "node scripts/build-extension.js",
     "check:generated": "node scripts/build-extension.js --check",
+    "check:clean-tree": "git diff --exit-code -- extension/content.js",
     "cert:preflight": "node scripts/certify-extension.js preflight",
     "cert:manifest-audit": "node scripts/certify-extension.js manifest",
     "cert:artifact-index": "node scripts/certify-extension.js artifacts --out test-results/extension-artifact-index.json",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "npm run build:extension",
     "build:extension": "node scripts/build-extension.js",
     "check:generated": "node scripts/build-extension.js --check",
+    "check:committed": "node scripts/build-extension.js --check-committed",
     "check:clean-tree": "git diff --exit-code -- extension/content.js",
     "cert:preflight": "node scripts/certify-extension.js preflight",
     "cert:manifest-audit": "node scripts/certify-extension.js manifest",

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -3,22 +3,37 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const root = path.resolve(__dirname, '..');
 const userscriptPath = path.join(root, 'ghost-in-the-loop.user.js');
 const extensionPath = path.join(root, 'extension', 'content.js');
 const checkOnly = process.argv.includes('--check');
+/* --check-committed reads both sides from git instead of the working tree, so
+   parity holds even if an earlier step in the same job rewrote the artifact. */
+const checkCommitted = process.argv.includes('--check-committed');
 
-const userscript = fs.readFileSync(userscriptPath, 'utf8');
-const headerEnd = '// ==/UserScript==';
-const markerIndex = userscript.indexOf(headerEnd);
-
-if (markerIndex < 0) {
-  throw new Error('Userscript metadata terminator was not found.');
+function readCommitted(relPath) {
+  const r = spawnSync('git', ['show', `HEAD:${relPath}`], {
+    cwd: root, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024
+  });
+  if (r.status !== 0) {
+    console.error(`Could not read HEAD:${relPath} from git.`);
+    process.exit(1);
+  }
+  return r.stdout;
 }
 
-const runtime = userscript.slice(markerIndex + headerEnd.length).trim();
-const wrapper = `/* GENERATED FILE — edit ghost-in-the-loop.user.js, then run npm run build.
+function build(userscript) {
+  const headerEnd = '// ==/UserScript==';
+  const markerIndex = userscript.indexOf(headerEnd);
+
+  if (markerIndex < 0) {
+    throw new Error('Userscript metadata terminator was not found.');
+  }
+
+  const runtime = userscript.slice(markerIndex + headerEnd.length).trim();
+  return `/* GENERATED FILE — edit ghost-in-the-loop.user.js, then run npm run build.
    Firefox MV3 wrapper: GM_* compatibility over browser.storage.local. */
 const _store = typeof browser !== 'undefined' ? browser.storage.local : chrome.storage.local;
 const _cache = {};
@@ -46,8 +61,17 @@ _initStore().then(() => {
 ${runtime}
 });
 `;
+}
 
-if (checkOnly) {
+if (checkCommitted) {
+  const expected = build(readCommitted('ghost-in-the-loop.user.js'));
+  if (readCommitted('extension/content.js') !== expected) {
+    console.error('Committed extension/content.js does not match the committed userscript.');
+    process.exit(1);
+  }
+  console.log('Committed extension artifact matches the committed userscript.');
+} else if (checkOnly) {
+  const wrapper = build(fs.readFileSync(userscriptPath, 'utf8'));
   const current = fs.existsSync(extensionPath) ? fs.readFileSync(extensionPath, 'utf8') : '';
   if (current !== wrapper) {
     console.error('extension/content.js is stale. Run: npm run build');
@@ -55,6 +79,6 @@ if (checkOnly) {
   }
   console.log('Generated extension artifact is current.');
 } else {
-  fs.writeFileSync(extensionPath, wrapper);
+  fs.writeFileSync(extensionPath, build(fs.readFileSync(userscriptPath, 'utf8')));
   console.log('Generated extension/content.js from ghost-in-the-loop.user.js.');
 }

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -17,8 +17,16 @@ function readCommitted(relPath) {
   const r = spawnSync('git', ['show', `HEAD:${relPath}`], {
     cwd: root, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024
   });
+  /* A gate that fails closed still has to say why: distinguish "git is absent"
+     from "the blob is absent" instead of reporting both the same way. */
+  if (r.error) {
+    console.error(`Could not run git to read HEAD:${relPath} — ${r.error.message}`);
+    process.exit(1);
+  }
   if (r.status !== 0) {
-    console.error(`Could not read HEAD:${relPath} from git.`);
+    const detail = (r.stderr || '').trim()
+      || (r.signal ? `killed by signal ${r.signal}` : `git exited ${r.status}`);
+    console.error(`Could not read HEAD:${relPath} from git — ${detail}`);
     process.exit(1);
   }
   return r.stdout;

--- a/tests/source-of-truth.test.js
+++ b/tests/source-of-truth.test.js
@@ -17,8 +17,10 @@ describe('canonical source tree', () => {
     expect(fs.existsSync(path.join(ROOT, 'dev'))).toBe(false);
   });
 
+  /* --check-committed, not --check: jest runs after cert:base, so a working-tree
+     comparison would report parity the build step had just manufactured. */
   test('the committed extension artifact matches the canonical userscript', () => {
-    const result = spawnSync(process.execPath, ['scripts/build-extension.js', '--check'], {
+    const result = spawnSync(process.execPath, ['scripts/build-extension.js', '--check-committed'], {
       cwd: ROOT,
       encoding: 'utf8'
     });


### PR DESCRIPTION
`cert:base` ran `build:extension` before `check:generated`, so the parity gate
compared `extension/content.js` against bytes the same chain had just written.
Any modification to the committed artifact was overwritten and the check then
passed. The gate could not fail.

Reproduced on `171835c`: appending a line to the committed `extension/content.js`
and running `cert:base` exits 0, all gates green, and the added line is gone.

Three changes:

1. `cert:base` no longer builds. Parity is checked on the committed bytes — the
   artifact a clone or zip install actually runs. Both workflows check parity
   before certification.
2. `check:clean-tree` asserts certification did not rewrite the artifact, so a
   future step that rebuilds fails instead of hiding it.
3. `build-extension.js --check-committed` compares git blobs instead of working-tree
   files. `tests/source-of-truth.test.js` uses it, since jest runs after
   certification and a working-tree comparison there is self-confirming.

After: the same tamper exits 1 and the tampered line is still present.

No functional change to the userscript or the extension. Build output is
byte-identical (`2d04736c…` before and after the refactor).

### Needs a maintainer decision

This surfaces pre-existing drift rather than causing it: committed
`extension/content.js` is the 8.8.2 build, `ghost-in-the-loop.user.js` is 8.8.3.
`main` already fails 20 tests for this reason and the old `--check` fails there
too — the failure set is identical with and without this PR. A release-sync
commit (`npm run build`, version bump in `package.json` / `package-lock.json` /
`extension/manifest.json`, regenerate `candidate-identity.json`) is a separate
call I have deliberately left out, since regenerating the artifact would bundle
the 8.8.3 functional changes into a pipeline fix.
